### PR TITLE
feat: Enhance `transform` command with automatic fact sheet relationship generation

### DIFF
--- a/src/commands/transform.ts
+++ b/src/commands/transform.ts
@@ -166,7 +166,7 @@ export async function handleTransform(options: TransformCommandOptions) {
     await generateHTMLFiles(tempInputDir, htmlOutputDir);
 
     // Step 3: Merge HTML files with JSON data and create the final ZIP
-    logger.info('Merging HTML files with transformed data...');
+    logger.info('Step 3: Merging HTML files with transformed data...');
 
     // The fact-sheet tool creates a subdirectory with the property name inside htmlOutputDir
     // We need to find that subdirectory and copy its contents (not the directory itself)
@@ -213,8 +213,8 @@ export async function handleTransform(options: TransformCommandOptions) {
       }
     }
 
-    // Step 3.5: Generate fact_sheet relationships
-    logger.info('Generating fact_sheet relationships...');
+    // Step 4: Generate fact_sheet relationships
+    logger.info('Step 4: Generating fact_sheet relationships...');
 
     try {
       // Initialize services
@@ -239,8 +239,8 @@ export async function handleTransform(options: TransformCommandOptions) {
       logger.warn('Continuing without fact_sheet relationships');
     }
 
-    // Step 4: Create the final ZIP archive
-    logger.info('Creating final output ZIP...');
+    // Step 5: Create the final ZIP archive
+    logger.info('Step 5: Creating final output ZIP...');
 
     // Create a new ZIP file
     const finalZip = new AdmZip();

--- a/src/commands/transform.ts
+++ b/src/commands/transform.ts
@@ -13,6 +13,8 @@ import {
 } from '../utils/fact-sheet.js';
 import { runAIAgent } from '../utils/ai-agent.js';
 import { ZipExtractorService } from '../services/zip-extractor.service.js';
+import { FactSheetRelationshipService } from '../services/fact-sheet-relationship.service.js';
+import { SchemaManifestService } from '../services/schema-manifest.service.js';
 
 export interface TransformCommandOptions {
   outputZip?: string;
@@ -209,6 +211,32 @@ export async function handleTransform(options: TransformCommandOptions) {
           logger.debug(`Copied ${entry.name} to property directory`);
         }
       }
+    }
+
+    // Step 3.5: Generate fact_sheet relationships
+    logger.info('Generating fact_sheet relationships...');
+
+    try {
+      // Initialize services
+      const schemaManifestService = new SchemaManifestService();
+      const factSheetRelationshipService = new FactSheetRelationshipService(
+        schemaManifestService
+      );
+
+      // Generate all fact_sheet relationships
+      await factSheetRelationshipService.generateFactSheetRelationships(
+        propertyPath
+      );
+
+      logger.success('Successfully generated fact_sheet relationships');
+    } catch (error) {
+      logger.error(
+        `Failed to generate fact_sheet relationships: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      // Continue even if relationship generation fails
+      logger.warn('Continuing without fact_sheet relationships');
     }
 
     // Step 4: Create the final ZIP archive

--- a/src/services/fact-sheet-relationship.service.ts
+++ b/src/services/fact-sheet-relationship.service.ts
@@ -59,7 +59,7 @@ export class FactSheetRelationshipService {
     // Build the full generation command
     let fullCommand: string | null = null;
     if (commitHash) {
-      fullCommand = `npx git+https://github.com/elephant-xyz/fact-sheet-template.git#${commitHash} generate --input \${inputDir} --output \${outputDir} --inline-js --inline-css --inline-svg`;
+      fullCommand = `npx -y git+https://github.com/elephant-xyz/fact-sheet-template.git#${commitHash} generate --input \${inputDir} --output \${outputDir} --inline-js --inline-css --inline-svg`;
     }
 
     const factSheetContent: {

--- a/src/services/fact-sheet-relationship.service.ts
+++ b/src/services/fact-sheet-relationship.service.ts
@@ -1,0 +1,552 @@
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { SchemaManifestService } from './schema-manifest.service.js';
+import {
+  analyzeDatagroupFiles,
+  DatagroupFile,
+} from '../utils/datagroup-analyzer.js';
+import { logger } from '../utils/logger.js';
+
+interface ClassMapping {
+  fileName: string;
+  className: string;
+}
+
+interface ClassSchema {
+  title: string;
+  [key: string]: any;
+}
+
+interface DataGroupSchema {
+  properties: {
+    relationships: {
+      properties: {
+        [key: string]: {
+          cid?: string;
+          type?: string | string[];
+          description?: string;
+        };
+      };
+    };
+  };
+}
+
+export class FactSheetRelationshipService {
+  private readonly schemaManifestService: SchemaManifestService;
+  private readonly ipfsGateway: string;
+  private schemaCache: Map<string, any> = new Map();
+
+  constructor(
+    schemaManifestService: SchemaManifestService,
+    ipfsGateway: string = 'https://gateway.pinata.cloud/ipfs'
+  ) {
+    this.schemaManifestService = schemaManifestService;
+    this.ipfsGateway = ipfsGateway.endsWith('/')
+      ? ipfsGateway.slice(0, -1)
+      : ipfsGateway;
+  }
+
+  /**
+   * Generate fact_sheet.json file
+   */
+  async generateFactSheetFile(outputDir: string): Promise<void> {
+    const factSheetPath = path.join(outputDir, 'fact_sheet.json');
+    const factSheetContent = {
+      ipfs_url: './index.html',
+    };
+
+    await fsPromises.writeFile(
+      factSheetPath,
+      JSON.stringify(factSheetContent, null, 2),
+      'utf-8'
+    );
+
+    logger.info(`Generated fact_sheet.json file at ${factSheetPath}`);
+  }
+
+  /**
+   * Fetch schema from IPFS with caching
+   */
+  private async fetchSchema(cid: string): Promise<any> {
+    if (this.schemaCache.has(cid)) {
+      return this.schemaCache.get(cid);
+    }
+
+    const url = `${this.ipfsGateway}/${cid}`;
+    logger.debug(`Fetching schema from IPFS: ${cid}`);
+
+    try {
+      const response = await fetch(url, {
+        headers: {
+          'User-Agent': 'elephant-cli/1.0',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const schema = await response.json();
+      logger.debug(
+        `Fetched schema ${cid}, type: ${schema.$schema ? 'JSON Schema' : 'unknown'}, has properties: ${!!schema.properties}`
+      );
+
+      // Check if this looks like a proper schema
+      if (!schema || typeof schema !== 'object') {
+        throw new Error(`Invalid schema format for ${cid}`);
+      }
+
+      this.schemaCache.set(cid, schema);
+      return schema;
+    } catch (error) {
+      logger.error(`Error fetching schema ${cid}: ${error}`);
+      throw error;
+    }
+  }
+
+  /**
+   * Process a single datagroup and collect class mappings
+   */
+  private async processDatagroup(
+    datagroupFile: DatagroupFile,
+    outputDir: string
+  ): Promise<ClassMapping[]> {
+    const classMappings: ClassMapping[] = [];
+
+    try {
+      // Read the datagroup file
+      const datagroupContent = JSON.parse(
+        await fsPromises.readFile(datagroupFile.filePath, 'utf-8')
+      );
+
+      // Fetch the datagroup schema
+      const datagroupSchema: DataGroupSchema = await this.fetchSchema(
+        datagroupFile.dataGroupCid
+      );
+
+      if (!datagroupSchema.properties?.relationships?.properties) {
+        logger.warn(
+          `Datagroup schema ${datagroupFile.dataGroupCid} has no relationships properties`
+        );
+        return classMappings;
+      }
+
+      // Process each relationship in the datagroup
+      for (const [relName, relValue] of Object.entries(
+        datagroupContent.relationships || {}
+      )) {
+        if (relValue === null || relValue === undefined) {
+          continue;
+        }
+
+        // Get the relationship schema CID from datagroup schema
+        const relSchemaSpec =
+          datagroupSchema.properties.relationships.properties[relName];
+        if (!relSchemaSpec?.cid) {
+          logger.debug(
+            `No CID found for relationship ${relName} in datagroup schema, processing data directly`
+          );
+          // For relationships without schema CID (like property_has_tax, property_has_sales_history),
+          // we'll process the actual relationship files to extract class mappings
+          await this.extractFileMappingsWithoutSchema(
+            relValue,
+            relName,
+            classMappings,
+            outputDir
+          );
+          continue;
+        }
+
+        const relationshipSchemaCid = relSchemaSpec.cid;
+
+        // Fetch the relationship schema
+        const relationshipSchema = await this.fetchSchema(
+          relationshipSchemaCid
+        );
+
+        // The relationship schema has properties.from.cid and properties.to.cid structure
+        const fromCid = relationshipSchema?.properties?.from?.cid;
+        const toCid = relationshipSchema?.properties?.to?.cid;
+
+        // Validate relationship schema structure
+        if (!fromCid || !toCid) {
+          logger.debug(
+            `Relationship schema ${relationshipSchemaCid} missing from/to cid properties. Structure: ${JSON.stringify(relationshipSchema)}`
+          );
+          continue;
+        }
+
+        // Fetch the "from" and "to" class schemas
+        const fromClassSchema: ClassSchema = await this.fetchSchema(fromCid);
+        const toClassSchema: ClassSchema = await this.fetchSchema(toCid);
+
+        const fromClassName = fromClassSchema.title;
+        const toClassName = toClassSchema.title;
+
+        // Process the relationship value to find file references
+        logger.debug(
+          `Processing relationship ${relName} with from=${fromClassName}, to=${toClassName}`
+        );
+        await this.extractFileMappings(
+          relValue,
+          fromClassName,
+          toClassName,
+          classMappings,
+          outputDir
+        );
+      }
+
+      return classMappings;
+    } catch (error) {
+      logger.error(
+        `Error processing datagroup ${datagroupFile.fileName}: ${error}`
+      );
+      return classMappings;
+    }
+  }
+
+  /**
+   * Extract file mappings from relationship values without schema
+   * This is used for relationships like property_has_tax where there's no schema CID
+   */
+  private async extractFileMappingsWithoutSchema(
+    relValue: any,
+    relName: string,
+    classMappings: ClassMapping[],
+    outputDir: string
+  ): Promise<void> {
+    logger.debug(
+      `extractFileMappingsWithoutSchema called for ${relName} with relValue: ${JSON.stringify(relValue)}`
+    );
+
+    // Derive class names from relationship name
+    // e.g., "property_has_tax" -> fromClass: "property", toClass: "tax"
+    // e.g., "property_has_sales_history" -> fromClass: "property", toClass: "sales_history"
+    const parts = relName.split('_has_');
+    const fromClassName = parts[0] || 'unknown';
+    const toClassName = parts[1] || 'unknown';
+
+    // Process the relationship value to extract files
+    await this.extractFileMappings(
+      relValue,
+      fromClassName,
+      toClassName,
+      classMappings,
+      outputDir
+    );
+  }
+
+  /**
+   * Extract file mappings from relationship values
+   */
+  private async extractFileMappings(
+    relValue: any,
+    fromClassName: string,
+    toClassName: string,
+    classMappings: ClassMapping[],
+    outputDir: string
+  ): Promise<void> {
+    logger.debug(
+      `extractFileMappings called with relValue: ${JSON.stringify(relValue)}`
+    );
+    if (Array.isArray(relValue)) {
+      // Process array of relationships - check this FIRST
+      for (const item of relValue) {
+        await this.extractFileMappings(
+          item,
+          fromClassName,
+          toClassName,
+          classMappings,
+          outputDir
+        );
+      }
+    } else if (typeof relValue === 'object' && relValue !== null) {
+      // Check if it's a direct file reference
+      if ('/' in relValue && typeof relValue['/'] === 'string') {
+        const filePath = relValue['/'];
+        logger.debug(`Found file reference: ${filePath}`);
+        if (filePath.startsWith('./')) {
+          await this.addMappingFromFile(
+            filePath,
+            fromClassName,
+            toClassName,
+            classMappings,
+            outputDir
+          );
+        }
+      } else if ('from' in relValue || 'to' in relValue) {
+        // It's a relationship object with from/to
+        if (
+          relValue.from &&
+          typeof relValue.from === 'object' &&
+          '/' in relValue.from
+        ) {
+          const fromPath = relValue.from['/'];
+          if (fromPath && fromPath.startsWith('./')) {
+            const fileName = path.basename(fromPath);
+            if (!classMappings.some((m) => m.fileName === fileName)) {
+              classMappings.push({ fileName, className: fromClassName });
+            }
+          }
+        }
+        if (
+          relValue.to &&
+          typeof relValue.to === 'object' &&
+          '/' in relValue.to
+        ) {
+          const toPath = relValue.to['/'];
+          if (toPath && toPath.startsWith('./')) {
+            const fileName = path.basename(toPath);
+            if (!classMappings.some((m) => m.fileName === fileName)) {
+              classMappings.push({ fileName, className: toClassName });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Read relationship file and add mappings based on from/to references
+   */
+  private async addMappingFromFile(
+    filePath: string,
+    fromClassName: string,
+    toClassName: string,
+    classMappings: ClassMapping[],
+    outputDir: string
+  ): Promise<void> {
+    const fullPath = path.join(outputDir, path.basename(filePath));
+    logger.debug(`addMappingFromFile: Reading ${fullPath}`);
+
+    try {
+      const content = JSON.parse(await fsPromises.readFile(fullPath, 'utf-8'));
+      logger.debug(
+        `Content of ${path.basename(filePath)}: ${JSON.stringify(content)}`
+      );
+
+      if (
+        content.from &&
+        typeof content.from === 'object' &&
+        '/' in content.from
+      ) {
+        const fromPath = content.from['/'];
+        if (fromPath && fromPath.startsWith('./')) {
+          const fileName = path.basename(fromPath);
+          if (!classMappings.some((m) => m.fileName === fileName)) {
+            classMappings.push({ fileName, className: fromClassName });
+            logger.debug(`Added mapping: ${fileName} -> ${fromClassName}`);
+          } else {
+            logger.debug(`Mapping already exists for ${fileName}`);
+          }
+        }
+      }
+
+      if (content.to && typeof content.to === 'object' && '/' in content.to) {
+        const toPath = content.to['/'];
+        if (toPath && toPath.startsWith('./')) {
+          const fileName = path.basename(toPath);
+          if (!classMappings.some((m) => m.fileName === fileName)) {
+            classMappings.push({ fileName, className: toClassName });
+            logger.debug(`Added mapping: ${fileName} -> ${toClassName}`);
+          } else {
+            logger.debug(`Mapping already exists for ${fileName}`);
+          }
+        }
+      }
+    } catch (error) {
+      logger.debug(`Could not read relationship file ${fullPath}: ${error}`);
+    }
+  }
+
+  /**
+   * Generate relationship files from classes to fact_sheet
+   */
+  private async generateFactSheetRelationshipFiles(
+    classMappings: ClassMapping[],
+    outputDir: string
+  ): Promise<Map<string, string>> {
+    const newRelationshipFiles = new Map<string, string>();
+
+    logger.debug(
+      `Generating fact_sheet relationships for ${classMappings.length} class mappings`
+    );
+    for (const mapping of classMappings) {
+      const baseFileName = mapping.fileName.replace('.json', '');
+      const relationshipFileName = `relationship_${baseFileName}_to_fact_sheet.json`;
+      const relationshipPath = path.join(outputDir, relationshipFileName);
+
+      const relationshipContent = {
+        from: {
+          '/': `./${mapping.fileName}`,
+        },
+        to: {
+          '/': './fact_sheet.json',
+        },
+      };
+
+      await fsPromises.writeFile(
+        relationshipPath,
+        JSON.stringify(relationshipContent, null, 2),
+        'utf-8'
+      );
+
+      logger.debug(`Generated relationship file: ${relationshipFileName}`);
+
+      // Map class name to relationship file
+      const relationshipKey = `${mapping.className}_has_fact_sheet`;
+      newRelationshipFiles.set(relationshipKey, relationshipFileName);
+    }
+
+    return newRelationshipFiles;
+  }
+
+  /**
+   * Update datagroup files with new fact_sheet relationships
+   */
+  private async updateDatagroupFiles(
+    datagroupFiles: DatagroupFile[],
+    classMappings: ClassMapping[],
+    _newRelationshipFiles: Map<string, string>
+  ): Promise<void> {
+    // Create a map of class names that have fact_sheet relationships
+    const classesWithFactSheet = new Set(classMappings.map((m) => m.className));
+
+    for (const datagroupFile of datagroupFiles) {
+      const content = JSON.parse(
+        await fsPromises.readFile(datagroupFile.filePath, 'utf-8')
+      );
+
+      let hasUpdates = false;
+
+      // Add fact_sheet relationships for ALL classes found in classMappings
+      for (const className of classesWithFactSheet) {
+        const relationshipKey = `${className}_has_fact_sheet`;
+
+        // Check if this relationship already exists
+        if (!content.relationships[relationshipKey]) {
+          // Find all files for this class (there might be multiple, e.g., tax_1, tax_2, etc.)
+          const classMappingsForClass = classMappings.filter(
+            (m) => m.className === className
+          );
+
+          if (classMappingsForClass.length === 1) {
+            // Single file for this class
+            const classMapping = classMappingsForClass[0];
+            const baseFileName = classMapping.fileName.replace('.json', '');
+            const relationshipFileName = `relationship_${baseFileName}_to_fact_sheet.json`;
+
+            content.relationships[relationshipKey] = {
+              '/': `./${relationshipFileName}`,
+            };
+            hasUpdates = true;
+            logger.debug(
+              `Added ${relationshipKey} to ${datagroupFile.fileName}`
+            );
+          } else if (classMappingsForClass.length > 1) {
+            // Multiple files for this class - create an array
+            const relationshipArray = classMappingsForClass.map((mapping) => {
+              const baseFileName = mapping.fileName.replace('.json', '');
+              const relationshipFileName = `relationship_${baseFileName}_to_fact_sheet.json`;
+              return {
+                '/': `./${relationshipFileName}`,
+              };
+            });
+
+            content.relationships[relationshipKey] = relationshipArray;
+            hasUpdates = true;
+            logger.debug(
+              `Added ${relationshipKey} array with ${relationshipArray.length} items to ${datagroupFile.fileName}`
+            );
+          }
+        }
+      }
+
+      // Write back the updated content if there were changes
+      if (hasUpdates) {
+        await fsPromises.writeFile(
+          datagroupFile.filePath,
+          JSON.stringify(content, null, 2),
+          'utf-8'
+        );
+        logger.info(
+          `Updated datagroup file ${datagroupFile.fileName} with fact_sheet relationships`
+        );
+      }
+    }
+  }
+
+  /**
+   * Main method to generate all fact_sheet relationships
+   */
+  async generateFactSheetRelationships(outputDir: string): Promise<void> {
+    logger.info('Generating fact_sheet relationships...');
+
+    // Always generate fact_sheet.json first
+    try {
+      await this.generateFactSheetFile(outputDir);
+    } catch (error) {
+      logger.error(`Failed to generate fact_sheet.json: ${error}`);
+      return;
+    }
+
+    try {
+      // Ensure schema manifest is loaded
+      await this.schemaManifestService.loadSchemaManifest();
+    } catch (error) {
+      logger.error(`Failed to load schema manifest: ${error}`);
+      // fact_sheet.json already created, just return
+      return;
+    }
+
+    try {
+      // Step 2: Find all datagroup files
+      const datagroupFiles = await analyzeDatagroupFiles(
+        outputDir,
+        this.schemaManifestService
+      );
+      logger.info(`Found ${datagroupFiles.length} datagroup files`);
+
+      // Step 3: Process each datagroup to collect class mappings
+      const allClassMappings: ClassMapping[] = [];
+      for (const datagroupFile of datagroupFiles) {
+        logger.debug(
+          `Processing datagroup: ${datagroupFile.label} (${datagroupFile.fileName})`
+        );
+        const mappings = await this.processDatagroup(datagroupFile, outputDir);
+
+        // Add unique mappings
+        for (const mapping of mappings) {
+          if (!allClassMappings.some((m) => m.fileName === mapping.fileName)) {
+            allClassMappings.push(mapping);
+          }
+        }
+      }
+
+      logger.info(`Identified ${allClassMappings.length} unique class files`);
+
+      // Step 4: Generate relationship files from classes to fact_sheet
+      const newRelationshipFiles =
+        await this.generateFactSheetRelationshipFiles(
+          allClassMappings,
+          outputDir
+        );
+
+      logger.info(
+        `Generated ${newRelationshipFiles.size} fact_sheet relationship files`
+      );
+
+      // Step 5: Update datagroup files with new relationships
+      await this.updateDatagroupFiles(
+        datagroupFiles,
+        allClassMappings,
+        newRelationshipFiles
+      );
+
+      logger.success('Successfully generated all fact_sheet relationships');
+    } catch (error) {
+      logger.error(`Error generating fact_sheet relationships: ${error}`);
+      // fact_sheet.json was already created, so we can consider this a partial success
+    }
+  }
+}

--- a/src/utils/fact-sheet.ts
+++ b/src/utils/fact-sheet.ts
@@ -128,6 +128,31 @@ export async function installOrUpdateFactSheet(): Promise<void> {
   }
 }
 
+export function getFactSheetCommitHash(): string | null {
+  try {
+    // The fact-sheet tool is typically installed in ~/.elephant-fact-sheet
+    const factSheetRepoPath = path.join(os.homedir(), '.elephant-fact-sheet');
+
+    if (!existsSync(factSheetRepoPath)) {
+      logger.debug('Fact-sheet repository not found at ~/.elephant-fact-sheet');
+      return null;
+    }
+
+    // Get the current commit hash
+    const commitHash = execSync('git rev-parse HEAD', {
+      cwd: factSheetRepoPath,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
+
+    logger.debug(`Fact-sheet tool commit hash: ${commitHash}`);
+    return commitHash;
+  } catch (error) {
+    logger.debug(`Could not get fact-sheet commit hash: ${error}`);
+    return null;
+  }
+}
+
 export async function generateHTMLFiles(
   inputDir: string,
   outputDir: string

--- a/tests/unit/services/fact-sheet-relationship.service.test.ts
+++ b/tests/unit/services/fact-sheet-relationship.service.test.ts
@@ -147,7 +147,7 @@ describe('FactSheetRelationshipService', () => {
       expect(content).toEqual({
         ipfs_url: './index.html',
         full_generation_command:
-          'npx git+https://github.com/elephant-xyz/fact-sheet-template.git#abc123def456789012345678901234567890abcd generate --input ${inputDir} --output ${outputDir} --inline-js --inline-css --inline-svg',
+          'npx -y git+https://github.com/elephant-xyz/fact-sheet-template.git#abc123def456789012345678901234567890abcd generate --input ${inputDir} --output ${outputDir} --inline-js --inline-css --inline-svg',
       });
     });
 

--- a/tests/unit/services/fact-sheet-relationship.service.test.ts
+++ b/tests/unit/services/fact-sheet-relationship.service.test.ts
@@ -1,0 +1,690 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fsPromises } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { FactSheetRelationshipService } from '../../../src/services/fact-sheet-relationship.service.js';
+import { SchemaManifestService } from '../../../src/services/schema-manifest.service.js';
+
+describe('FactSheetRelationshipService', () => {
+  let tempDir: string;
+  let schemaManifestService: SchemaManifestService;
+  let service: FactSheetRelationshipService;
+
+  // Mock data
+  const mockSchemaManifest = {
+    County: { ipfsCid: 'bafkreicountyschema', type: 'dataGroup' },
+    property: { ipfsCid: 'bafkreipropertyclass', type: 'class' },
+    address: { ipfsCid: 'bafkreiaddressclass', type: 'class' },
+  };
+
+  const mockDatagroupSchema = {
+    properties: {
+      label: { type: 'string' },
+      relationships: {
+        properties: {
+          property_has_address: {
+            cid: 'bafkreirelationshipschema',
+            type: 'string',
+          },
+        },
+      },
+    },
+  };
+
+  const mockRelationshipSchema = {
+    properties: {
+      from: {
+        cid: 'bafkreipropertyclass',
+        description: 'Reference to property class',
+        type: 'string',
+      },
+      to: {
+        cid: 'bafkreiaddressclass',
+        description: 'Reference to address class',
+        type: 'string',
+      },
+    },
+  };
+
+  const mockPropertyClassSchema = {
+    title: 'property',
+    type: 'object',
+    properties: {},
+  };
+
+  const mockAddressClassSchema = {
+    title: 'address',
+    type: 'object',
+    properties: {},
+  };
+
+  beforeEach(async () => {
+    // Create temporary directory
+    const tempDirBase = path.join(tmpdir(), 'elephant-cli-test-');
+    tempDir = await fsPromises.mkdtemp(tempDirBase);
+
+    // Initialize services
+    schemaManifestService = new SchemaManifestService();
+
+    // Mock schema manifest loading
+    vi.spyOn(schemaManifestService, 'loadSchemaManifest').mockResolvedValue(
+      mockSchemaManifest as any
+    );
+    vi.spyOn(
+      schemaManifestService,
+      'getDataGroupCidByLabel'
+    ).mockImplementation((label) => {
+      return label === 'County' ? 'bafkreicountyschema' : null;
+    });
+
+    // Create service with mocked fetch
+    service = new FactSheetRelationshipService(schemaManifestService);
+
+    // Mock fetch for schema retrieval
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('bafkreicountyschema')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockDatagroupSchema),
+        });
+      }
+      if (url.includes('bafkreirelationshipschema')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockRelationshipSchema),
+        });
+      }
+      if (url.includes('bafkreipropertyclass')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockPropertyClassSchema),
+        });
+      }
+      if (url.includes('bafkreiaddressclass')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockAddressClassSchema),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+    }) as any;
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    try {
+      await fsPromises.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+    vi.restoreAllMocks();
+  });
+
+  describe('generateFactSheetFile', () => {
+    it('should create fact_sheet.json with correct content', async () => {
+      await service.generateFactSheetFile(tempDir);
+
+      const factSheetPath = path.join(tempDir, 'fact_sheet.json');
+      const exists = await fsPromises
+        .access(factSheetPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+
+      const content = JSON.parse(
+        await fsPromises.readFile(factSheetPath, 'utf-8')
+      );
+      expect(content).toEqual({
+        ipfs_url: './index.html',
+      });
+    });
+  });
+
+  describe('generateFactSheetRelationships', () => {
+    beforeEach(async () => {
+      // Create sample data files
+      const countyDatagroup = {
+        label: 'County',
+        relationships: {
+          property_has_address: {
+            '/': './relationship_property_address.json',
+          },
+        },
+      };
+
+      const relationshipFile = {
+        from: {
+          '/': './property.json',
+        },
+        to: {
+          '/': './address.json',
+        },
+      };
+
+      const propertyFile = {
+        id: '123',
+        type: 'residential',
+      };
+
+      const addressFile = {
+        street: '123 Main St',
+        city: 'Example City',
+      };
+
+      // Write files to temp directory
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(countyDatagroup, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_address.json'),
+        JSON.stringify(relationshipFile, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property.json'),
+        JSON.stringify(propertyFile, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'address.json'),
+        JSON.stringify(addressFile, null, 2)
+      );
+    });
+
+    it('should generate fact_sheet.json', async () => {
+      await service.generateFactSheetRelationships(tempDir);
+
+      const factSheetPath = path.join(tempDir, 'fact_sheet.json');
+      const exists = await fsPromises
+        .access(factSheetPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+
+    it('should create relationship files from classes to fact_sheet', async () => {
+      await service.generateFactSheetRelationships(tempDir);
+
+      // Check for property to fact_sheet relationship
+      const propertyRelPath = path.join(
+        tempDir,
+        'relationship_property_to_fact_sheet.json'
+      );
+      const propertyRelExists = await fsPromises
+        .access(propertyRelPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(propertyRelExists).toBe(true);
+
+      if (propertyRelExists) {
+        const propertyRelContent = JSON.parse(
+          await fsPromises.readFile(propertyRelPath, 'utf-8')
+        );
+        expect(propertyRelContent).toEqual({
+          from: { '/': './property.json' },
+          to: { '/': './fact_sheet.json' },
+        });
+      }
+
+      // Check for address to fact_sheet relationship
+      const addressRelPath = path.join(
+        tempDir,
+        'relationship_address_to_fact_sheet.json'
+      );
+      const addressRelExists = await fsPromises
+        .access(addressRelPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(addressRelExists).toBe(true);
+
+      if (addressRelExists) {
+        const addressRelContent = JSON.parse(
+          await fsPromises.readFile(addressRelPath, 'utf-8')
+        );
+        expect(addressRelContent).toEqual({
+          from: { '/': './address.json' },
+          to: { '/': './fact_sheet.json' },
+        });
+      }
+    });
+
+    it('should update datagroup files with fact_sheet relationships', async () => {
+      await service.generateFactSheetRelationships(tempDir);
+
+      // Read the updated datagroup file
+      const datagroupPath = path.join(tempDir, 'bafkreicountyschema.json');
+      const datagroupContent = JSON.parse(
+        await fsPromises.readFile(datagroupPath, 'utf-8')
+      );
+
+      // Check that new relationships were added
+      expect(datagroupContent.relationships).toHaveProperty(
+        'property_has_fact_sheet'
+      );
+      expect(datagroupContent.relationships).toHaveProperty(
+        'address_has_fact_sheet'
+      );
+
+      // Verify the relationship references
+      expect(datagroupContent.relationships.property_has_fact_sheet).toEqual({
+        '/': './relationship_property_to_fact_sheet.json',
+      });
+
+      expect(datagroupContent.relationships.address_has_fact_sheet).toEqual({
+        '/': './relationship_address_to_fact_sheet.json',
+      });
+    });
+
+    it('should handle arrays of relationships', async () => {
+      // Add a datagroup with array relationships
+      const datagroupWithArray = {
+        label: 'County',
+        relationships: {
+          property_has_address: [
+            { '/': './relationship_property_address_1.json' },
+            { '/': './relationship_property_address_2.json' },
+          ],
+        },
+      };
+
+      const relationshipFile1 = {
+        from: { '/': './property1.json' },
+        to: { '/': './address1.json' },
+      };
+
+      const relationshipFile2 = {
+        from: { '/': './property2.json' },
+        to: { '/': './address2.json' },
+      };
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(datagroupWithArray, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_address_1.json'),
+        JSON.stringify(relationshipFile1, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_address_2.json'),
+        JSON.stringify(relationshipFile2, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property1.json'),
+        JSON.stringify({ id: '1' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property2.json'),
+        JSON.stringify({ id: '2' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'address1.json'),
+        JSON.stringify({ street: 'Street 1' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'address2.json'),
+        JSON.stringify({ street: 'Street 2' }, null, 2)
+      );
+
+      await service.generateFactSheetRelationships(tempDir);
+
+      // Check that relationship files were created for all classes
+      const expectedRelFiles = [
+        'relationship_property1_to_fact_sheet.json',
+        'relationship_property2_to_fact_sheet.json',
+        'relationship_address1_to_fact_sheet.json',
+        'relationship_address2_to_fact_sheet.json',
+      ];
+
+      for (const relFile of expectedRelFiles) {
+        const relPath = path.join(tempDir, relFile);
+        const exists = await fsPromises
+          .access(relPath)
+          .then(() => true)
+          .catch(() => false);
+        expect(exists).toBe(true);
+      }
+    });
+
+    it('should handle null relationships gracefully', async () => {
+      const datagroupWithNull = {
+        label: 'County',
+        relationships: {
+          property_has_address: {
+            '/': './relationship_property_address.json',
+          },
+          property_has_owner: null,
+          property_has_history: undefined,
+        },
+      };
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(datagroupWithNull, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_address.json'),
+        JSON.stringify(
+          {
+            from: { '/': './property.json' },
+            to: { '/': './address.json' },
+          },
+          null,
+          2
+        )
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property.json'),
+        JSON.stringify({ id: '123' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'address.json'),
+        JSON.stringify({ street: '123 Main St' }, null, 2)
+      );
+
+      // Should not throw error
+      await expect(
+        service.generateFactSheetRelationships(tempDir)
+      ).resolves.not.toThrow();
+
+      // Should still create relationship files for valid relationships
+      const propertyRelPath = path.join(
+        tempDir,
+        'relationship_property_to_fact_sheet.json'
+      );
+      const exists = await fsPromises
+        .access(propertyRelPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+
+    it('should handle relationships without schema CIDs (like property_has_tax)', async () => {
+      // Mock datagroup schema without CID for property_has_tax
+      const mockDatagroupSchemaWithoutCid = {
+        properties: {
+          label: { type: 'string' },
+          relationships: {
+            properties: {
+              property_has_tax: {
+                // No cid property - simulating property_has_tax scenario
+                type: 'array',
+                description:
+                  'Array of references to property_to_tax relationship schemas',
+              },
+            },
+          },
+        },
+      };
+
+      // Override the mock for this test
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        if (url.includes('bafkreicountyschema')) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(mockDatagroupSchemaWithoutCid),
+          });
+        }
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+        });
+      }) as any;
+
+      const datagroupWithTax = {
+        label: 'County',
+        relationships: {
+          property_has_tax: [
+            { '/': './relationship_property_tax_1.json' },
+            { '/': './relationship_property_tax_2.json' },
+          ],
+        },
+      };
+
+      const taxRelationshipFile1 = {
+        from: { '/': './property.json' },
+        to: { '/': './tax_1.json' },
+      };
+
+      const taxRelationshipFile2 = {
+        from: { '/': './property.json' },
+        to: { '/': './tax_2.json' },
+      };
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(datagroupWithTax, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_tax_1.json'),
+        JSON.stringify(taxRelationshipFile1, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'relationship_property_tax_2.json'),
+        JSON.stringify(taxRelationshipFile2, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property.json'),
+        JSON.stringify({ id: '123' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'tax_1.json'),
+        JSON.stringify({ year: 2023, amount: 1000 }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'tax_2.json'),
+        JSON.stringify({ year: 2024, amount: 1100 }, null, 2)
+      );
+
+      await service.generateFactSheetRelationships(tempDir);
+
+      // Check that relationship files were created for tax files
+      const expectedRelFiles = [
+        'relationship_property_to_fact_sheet.json',
+        'relationship_tax_1_to_fact_sheet.json',
+        'relationship_tax_2_to_fact_sheet.json',
+      ];
+
+      for (const relFile of expectedRelFiles) {
+        const relPath = path.join(tempDir, relFile);
+        const exists = await fsPromises
+          .access(relPath)
+          .then(() => true)
+          .catch(() => false);
+        expect(exists).toBe(true);
+      }
+
+      // Check the datagroup was updated with tax fact_sheet relationships
+      const datagroupPath = path.join(tempDir, 'bafkreicountyschema.json');
+      const datagroupContent = JSON.parse(
+        await fsPromises.readFile(datagroupPath, 'utf-8')
+      );
+
+      expect(datagroupContent.relationships).toHaveProperty(
+        'property_has_fact_sheet'
+      );
+      expect(datagroupContent.relationships).toHaveProperty(
+        'tax_has_fact_sheet'
+      );
+    });
+
+    it('should not duplicate class mappings', async () => {
+      // Create multiple datagroups referencing the same classes
+      const datagroup1 = {
+        label: 'County',
+        relationships: {
+          property_has_address: {
+            '/': './rel1.json',
+          },
+        },
+      };
+
+      const datagroup2 = {
+        label: 'County',
+        relationships: {
+          property_has_address: {
+            '/': './rel2.json',
+          },
+        },
+      };
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(datagroup1, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema2.json'),
+        JSON.stringify(datagroup2, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'rel1.json'),
+        JSON.stringify(
+          {
+            from: { '/': './property.json' },
+            to: { '/': './address.json' },
+          },
+          null,
+          2
+        )
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'rel2.json'),
+        JSON.stringify(
+          {
+            from: { '/': './property.json' },
+            to: { '/': './address.json' },
+          },
+          null,
+          2
+        )
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'property.json'),
+        JSON.stringify({ id: '123' }, null, 2)
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'address.json'),
+        JSON.stringify({ street: '123 Main St' }, null, 2)
+      );
+
+      await service.generateFactSheetRelationships(tempDir);
+
+      // Should only create one relationship file per class
+      const files = await fsPromises.readdir(tempDir);
+      const propertyRelFiles = files.filter(
+        (f) => f === 'relationship_property_to_fact_sheet.json'
+      );
+      const addressRelFiles = files.filter(
+        (f) => f === 'relationship_address_to_fact_sheet.json'
+      );
+
+      expect(propertyRelFiles.length).toBe(1);
+      expect(addressRelFiles.length).toBe(1);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should handle IPFS fetch errors gracefully', async () => {
+      // Create a fresh service instance with proper mocks
+      const testSchemaManifestService = new SchemaManifestService();
+
+      // Mock the loadSchemaManifest to succeed
+      vi.spyOn(
+        testSchemaManifestService,
+        'loadSchemaManifest'
+      ).mockResolvedValue({
+        County: { ipfsCid: 'bafkreicountyschema', type: 'dataGroup' },
+      } as any);
+
+      vi.spyOn(
+        testSchemaManifestService,
+        'getDataGroupCidByLabel'
+      ).mockImplementation((label) => {
+        return label === 'County' ? 'bafkreicountyschema' : null;
+      });
+
+      const testService = new FactSheetRelationshipService(
+        testSchemaManifestService
+      );
+
+      // Mock fetch to fail for IPFS schema fetches
+      global.fetch = vi
+        .fn()
+        .mockRejectedValue(new Error('Network error')) as any;
+
+      const datagroup = {
+        label: 'County',
+        relationships: {},
+      };
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'bafkreicountyschema.json'),
+        JSON.stringify(datagroup, null, 2)
+      );
+
+      // Should not throw, but log error
+      await expect(
+        testService.generateFactSheetRelationships(tempDir)
+      ).resolves.not.toThrow();
+
+      // fact_sheet.json should still be created
+      const factSheetPath = path.join(tempDir, 'fact_sheet.json');
+      const exists = await fsPromises
+        .access(factSheetPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+
+    it('should handle invalid JSON files', async () => {
+      await fsPromises.writeFile(
+        path.join(tempDir, 'invalid.json'),
+        'not valid json'
+      );
+
+      await fsPromises.writeFile(
+        path.join(tempDir, 'valid.json'),
+        JSON.stringify({ label: 'County', relationships: {} }, null, 2)
+      );
+
+      // Should skip invalid files and process valid ones
+      await expect(
+        service.generateFactSheetRelationships(tempDir)
+      ).resolves.not.toThrow();
+
+      // fact_sheet.json should still be created
+      const factSheetPath = path.join(tempDir, 'fact_sheet.json');
+      const exists = await fsPromises
+        .access(factSheetPath)
+        .then(() => true)
+        .catch(() => false);
+      expect(exists).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
feat: Enhance `transform` command with automatic fact sheet relationship generation

- Added functionality to generate `fact_sheet.json` and relationship files during the transformation process.
- Implemented `FactSheetRelationshipService` to handle relationship logic and schema fetching.
- Updated documentation to reflect new features and output structure.