### PR TITLE
fix: Ensure fact sheet relationships are always represented as arrays

### DIFF
--- a/src/services/fact-sheet-relationship.service.ts
+++ b/src/services/fact-sheet-relationship.service.ts
@@ -452,35 +452,20 @@ export class FactSheetRelationshipService {
             (m) => m.className === className
           );
 
-          if (classMappingsForClass.length === 1) {
-            // Single file for this class
-            const classMapping = classMappingsForClass[0];
-            const baseFileName = classMapping.fileName.replace('.json', '');
+          // Always create an array, even for single relationships
+          const relationshipArray = classMappingsForClass.map((mapping) => {
+            const baseFileName = mapping.fileName.replace('.json', '');
             const relationshipFileName = `relationship_${baseFileName}_to_fact_sheet.json`;
-
-            content.relationships[relationshipKey] = {
+            return {
               '/': `./${relationshipFileName}`,
             };
-            hasUpdates = true;
-            logger.debug(
-              `Added ${relationshipKey} to ${datagroupFile.fileName}`
-            );
-          } else if (classMappingsForClass.length > 1) {
-            // Multiple files for this class - create an array
-            const relationshipArray = classMappingsForClass.map((mapping) => {
-              const baseFileName = mapping.fileName.replace('.json', '');
-              const relationshipFileName = `relationship_${baseFileName}_to_fact_sheet.json`;
-              return {
-                '/': `./${relationshipFileName}`,
-              };
-            });
+          });
 
-            content.relationships[relationshipKey] = relationshipArray;
-            hasUpdates = true;
-            logger.debug(
-              `Added ${relationshipKey} array with ${relationshipArray.length} items to ${datagroupFile.fileName}`
-            );
-          }
+          content.relationships[relationshipKey] = relationshipArray;
+          hasUpdates = true;
+          logger.debug(
+            `Added ${relationshipKey} array with ${relationshipArray.length} item(s) to ${datagroupFile.fileName}`
+          );
         }
       }
 

--- a/tests/unit/services/fact-sheet-relationship.service.test.ts
+++ b/tests/unit/services/fact-sheet-relationship.service.test.ts
@@ -295,14 +295,18 @@ describe('FactSheetRelationshipService', () => {
         'address_has_fact_sheet'
       );
 
-      // Verify the relationship references
-      expect(datagroupContent.relationships.property_has_fact_sheet).toEqual({
-        '/': './relationship_property_to_fact_sheet.json',
-      });
+      // Verify the relationship references (should always be arrays)
+      expect(datagroupContent.relationships.property_has_fact_sheet).toEqual([
+        {
+          '/': './relationship_property_to_fact_sheet.json',
+        },
+      ]);
 
-      expect(datagroupContent.relationships.address_has_fact_sheet).toEqual({
-        '/': './relationship_address_to_fact_sheet.json',
-      });
+      expect(datagroupContent.relationships.address_has_fact_sheet).toEqual([
+        {
+          '/': './relationship_address_to_fact_sheet.json',
+        },
+      ]);
     });
 
     it('should handle arrays of relationships', async () => {
@@ -380,6 +384,24 @@ describe('FactSheetRelationshipService', () => {
           .catch(() => false);
         expect(exists).toBe(true);
       }
+
+      // Verify that datagroup was updated with fact_sheet relationships as arrays
+      const datagroupPath = path.join(tempDir, 'bafkreicountyschema.json');
+      const datagroupContent = JSON.parse(
+        await fsPromises.readFile(datagroupPath, 'utf-8')
+      );
+
+      // Property has multiple instances, should be an array with 2 items
+      expect(datagroupContent.relationships.property_has_fact_sheet).toEqual([
+        { '/': './relationship_property1_to_fact_sheet.json' },
+        { '/': './relationship_property2_to_fact_sheet.json' },
+      ]);
+
+      // Address has multiple instances, should be an array with 2 items
+      expect(datagroupContent.relationships.address_has_fact_sheet).toEqual([
+        { '/': './relationship_address1_to_fact_sheet.json' },
+        { '/': './relationship_address2_to_fact_sheet.json' },
+      ]);
     });
 
     it('should handle null relationships gracefully', async () => {
@@ -545,12 +567,16 @@ describe('FactSheetRelationshipService', () => {
         await fsPromises.readFile(datagroupPath, 'utf-8')
       );
 
-      expect(datagroupContent.relationships).toHaveProperty(
-        'property_has_fact_sheet'
-      );
-      expect(datagroupContent.relationships).toHaveProperty(
-        'tax_has_fact_sheet'
-      );
+      // Verify fact_sheet relationships are arrays
+      expect(datagroupContent.relationships.property_has_fact_sheet).toEqual([
+        { '/': './relationship_property_to_fact_sheet.json' },
+      ]);
+
+      // Tax has multiple instances, should be an array with 2 items
+      expect(datagroupContent.relationships.tax_has_fact_sheet).toEqual([
+        { '/': './relationship_tax_1_to_fact_sheet.json' },
+        { '/': './relationship_tax_2_to_fact_sheet.json' },
+      ]);
     });
 
     it('should not duplicate class mappings', async () => {


### PR DESCRIPTION
fix: Ensure fact sheet relationships are always represented as arrays in the FactSheetRelationshipService

Updated the relationship handling logic to consistently create arrays for relationships, even when there is a single mapping. Adjusted related unit tests to verify that relationship references are now arrays, ensuring compatibility with the new structure.