### PR TITLE
fix(transform): allow for invlaid json multiValueQueryString

### DIFF
--- a/src/commands/transform/index.ts
+++ b/src/commands/transform/index.ts
@@ -19,6 +19,7 @@ import {
 import { SchemaManifestService } from '../../services/schema-manifest.service.js';
 import { FactSheetRelationshipService } from '../../services/fact-sheet-relationship.service.js';
 import { SchemaCacheService } from '../../services/schema-cache.service.js';
+import { parseMultiValueQueryString } from './sourceHttpRequest.js';
 
 const INPUT_DIR = 'input';
 const OUTPUT_DIR = 'data';
@@ -238,7 +239,7 @@ async function handleSeedTransform(tempRoot: string) {
     url: seedRow.url,
     method: seedRow.method,
     multiValueQueryString: seedRow.multiValueQueryString?.trim()
-      ? JSON.parse(seedRow.multiValueQueryString)
+      ? parseMultiValueQueryString(seedRow.multiValueQueryString)
       : {},
   };
   const propSeedJson = JSON.stringify({

--- a/src/commands/transform/sourceHttpRequest.ts
+++ b/src/commands/transform/sourceHttpRequest.ts
@@ -1,0 +1,13 @@
+export function parseMultiValueQueryString(
+  queryString: string
+): Record<string, string[]> {
+  try {
+    return JSON.parse(queryString);
+  } catch (e) {
+    const replaced = queryString
+      .replace(/\\'/g, '__SQUOTE__') // protect \' inside strings
+      .replace(/'/g, '"') // replace remaining single quotes
+      .replace(/__SQUOTE__/g, "'"); // restore \' as real single quote
+    return JSON.parse(replaced);
+  }
+}

--- a/tests/unit/commands/transform/seed-transform.test.ts
+++ b/tests/unit/commands/transform/seed-transform.test.ts
@@ -1,109 +1,39 @@
 import { describe, it, expect } from 'vitest';
-import { parse } from 'csv-parse/sync';
+import { parseMultiValueQueryString } from '../../../../src/commands/transform/sourceHttpRequest.js';
 
-describe('Seed transform - multiValueQueryString handling', () => {
-  it('should handle empty multiValueQueryString', () => {
-    const csvContent = `parcel_id,address,method,url,multiValueQueryString,source_identifier,county
-12345,123 Main St,GET,https://api.example.com,,source123,TestCounty`;
-
-    const parsed = parse(csvContent, {
-      columns: true,
-      skip_empty_lines: true,
-    });
-    const seedRow = parsed[0];
-
-    const sourceHttpRequest = {
-      url: seedRow.url,
-      method: seedRow.method,
-      multiValueQueryString: seedRow.multiValueQueryString?.trim()
-        ? JSON.parse(seedRow.multiValueQueryString)
-        : {},
-    };
-
-    expect(sourceHttpRequest.multiValueQueryString).toEqual({});
+describe('parseMultiValueQueryString', () => {
+  it('should handle valid JSON', () => {
+    const result = parseMultiValueQueryString('{"key":"value"}');
+    expect(result).toEqual({ key: 'value' });
   });
 
-  it('should handle whitespace-only multiValueQueryString', () => {
-    const csvContent = `parcel_id,address,method,url,multiValueQueryString,source_identifier,county
-12345,123 Main St,GET,https://api.example.com,   ,source123,TestCounty`;
-
-    const parsed = parse(csvContent, {
-      columns: true,
-      skip_empty_lines: true,
-    });
-    const seedRow = parsed[0];
-
-    const sourceHttpRequest = {
-      url: seedRow.url,
-      method: seedRow.method,
-      multiValueQueryString: seedRow.multiValueQueryString?.trim()
-        ? JSON.parse(seedRow.multiValueQueryString)
-        : {},
-    };
-
-    expect(sourceHttpRequest.multiValueQueryString).toEqual({});
+  it('should handle empty object', () => {
+    const result = parseMultiValueQueryString('{}');
+    expect(result).toEqual({});
   });
 
-  it('should handle valid JSON in multiValueQueryString', () => {
-    const csvContent = `parcel_id,address,method,url,multiValueQueryString,source_identifier,county
-12345,123 Main St,GET,https://api.example.com,"{""key"":""value""}",source123,TestCounty`;
-
-    const parsed = parse(csvContent, {
-      columns: true,
-      skip_empty_lines: true,
-    });
-    const seedRow = parsed[0];
-
-    const sourceHttpRequest = {
-      url: seedRow.url,
-      method: seedRow.method,
-      multiValueQueryString: seedRow.multiValueQueryString?.trim()
-        ? JSON.parse(seedRow.multiValueQueryString)
-        : {},
-    };
-
-    expect(sourceHttpRequest.multiValueQueryString).toEqual({ key: 'value' });
+  it('should throw error for invalid JSON', () => {
+    expect(() => parseMultiValueQueryString('{invalid json}')).toThrow();
   });
 
-  it('should handle empty object {} in multiValueQueryString', () => {
-    const csvContent = `parcel_id,address,method,url,multiValueQueryString,source_identifier,county
-12345,123 Main St,GET,https://api.example.com,{},source123,TestCounty`;
-
-    const parsed = parse(csvContent, {
-      columns: true,
-      skip_empty_lines: true,
-    });
-    const seedRow = parsed[0];
-
-    const sourceHttpRequest = {
-      url: seedRow.url,
-      method: seedRow.method,
-      multiValueQueryString: seedRow.multiValueQueryString?.trim()
-        ? JSON.parse(seedRow.multiValueQueryString)
-        : {},
-    };
-
-    expect(sourceHttpRequest.multiValueQueryString).toEqual({});
+  it('should handle single-quoted strings', () => {
+    const result = parseMultiValueQueryString(
+      '{"key":"value","key2":"value2","key3":"\'value3\'"}'
+    );
+    expect(result).toEqual({ key: 'value', key2: 'value2', key3: "'value3'" });
   });
 
-  it('should throw error for invalid JSON in multiValueQueryString', () => {
-    const csvContent = `parcel_id,address,method,url,multiValueQueryString,source_identifier,county
-12345,123 Main St,GET,https://api.example.com,{invalid json},source123,TestCounty`;
+  it('should handle double-quoted strings', () => {
+    const result = parseMultiValueQueryString(
+      '{"key":"value","key2":"value2","key3":"\\"value3\\""}'
+    );
+    expect(result).toEqual({ key: 'value', key2: 'value2', key3: '"value3"' });
+  });
 
-    const parsed = parse(csvContent, {
-      columns: true,
-      skip_empty_lines: true,
-    });
-    const seedRow = parsed[0];
-
-    expect(() => {
-      const sourceHttpRequest = {
-        url: seedRow.url,
-        method: seedRow.method,
-        multiValueQueryString: seedRow.multiValueQueryString?.trim()
-          ? JSON.parse(seedRow.multiValueQueryString)
-          : {},
-      };
-    }).toThrow();
+  it('should handle escaped single quotes', () => {
+    const result = parseMultiValueQueryString(
+      '{"key":"value","key2":"value2","key3":"\'value3\'"}'
+    );
+    expect(result).toEqual({ key: 'value', key2: 'value2', key3: "'value3'" });
   });
 });


### PR DESCRIPTION
This pull request refactors how the `multiValueQueryString` field is parsed in the seed transform command, introducing a new utility function to handle edge cases with single-quoted JSON and updating related unit tests for better coverage and clarity. The main changes include replacing direct `JSON.parse` usage with a robust parsing function, adding new tests, and cleaning up outdated test logic.

### Parsing improvements

* Added a new utility function `parseMultiValueQueryString` in `sourceHttpRequest.ts` to handle both standard and single-quoted JSON strings, improving robustness when parsing `multiValueQueryString`.
* Updated the seed transform logic in `transform/index.ts` to use `parseMultiValueQueryString` instead of direct `JSON.parse`, ensuring more reliable parsing of incoming data. [[1]](diffhunk://#diff-3a7d1baf3457a81c45a43c0c31102bdd6956fd6297e7c40e5e3ebb6284828b61L241-R242) [[2]](diffhunk://#diff-3a7d1baf3457a81c45a43c0c31102bdd6956fd6297e7c40e5e3ebb6284828b61R22)

### Testing improvements

* Replaced the previous CSV-based integration-style tests in `seed-transform.test.ts` with focused unit tests for `parseMultiValueQueryString`, covering valid JSON, empty objects, invalid JSON, single-quoted strings, double-quoted strings, and escaped quotes.