### PR TITLE
feat: provide commands as lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "bin": {
     "elephant-cli": "./dist/index.js"
   },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./lib": {
+      "import": "./dist/lib/index.js",
+      "types": "./dist/lib/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "tsc && npm run copy:prompts",
     "copy:prompts": "mkdir -p dist/commands/generate-transform/prompts && cp -R src/commands/generate-transform/prompts/*.md dist/commands/generate-transform/prompts/",

--- a/src/commands/hash.ts
+++ b/src/commands/hash.ts
@@ -142,9 +142,12 @@ export async function handleHash(
     windowsFactor: 4,
   });
 
-  const config = createSubmitConfig({
-    maxConcurrentUploads: undefined,
-  });
+  const config = createSubmitConfig(
+    {
+      maxConcurrentUploads: undefined,
+    },
+    options.cwd
+  );
 
   // Keep a reference to csvReporterService to use in the final catch block
   let csvReporterServiceInstance: CsvReporterService | undefined =

--- a/src/commands/hash.ts
+++ b/src/commands/hash.ts
@@ -43,6 +43,7 @@ export interface HashCommandOptions {
   outputCsv: string;
   maxConcurrentTasks?: number;
   propertyCid?: string;
+  silent?: boolean;
 }
 
 export function registerHashCommand(program: Command) {
@@ -97,10 +98,12 @@ export async function handleHash(
   options: HashCommandOptions,
   serviceOverrides: HashServiceOverrides = {}
 ) {
-  console.log(
-    chalk.bold.blue('🐘 Elephant Network CLI - Hash (Single Property)')
-  );
-  console.log();
+  if (!options.silent) {
+    console.log(
+      chalk.bold.blue('🐘 Elephant Network CLI - Hash (Single Property)')
+    );
+    console.log();
+  }
 
   // Process single property ZIP input
   let processedInput;
@@ -113,7 +116,11 @@ export async function handleHash(
     logger.error(
       `Failed to process input: ${error instanceof Error ? error.message : String(error)}`
     );
-    process.exit(1);
+    if (options.silent) {
+      throw error;
+    } else {
+      process.exit(1);
+    }
   }
 
   const { actualInputDir, cleanup } = processedInput;
@@ -182,10 +189,16 @@ export async function handleHash(
     // not that it contains property subdirectories
     const dirStats = await fsPromises.stat(actualInputDir);
     if (!dirStats.isDirectory()) {
-      console.log(chalk.red('❌ Extracted path is not a directory'));
+      if (!options.silent) {
+        console.log(chalk.red('❌ Extracted path is not a directory'));
+      }
       await csvReporterService.finalize();
       await cleanup();
-      process.exit(1);
+      if (options.silent) {
+        throw new Error('Extracted path is not a directory');
+      } else {
+        process.exit(1);
+      }
     }
 
     const entries = await fsPromises.readdir(actualInputDir, {
@@ -631,29 +644,31 @@ export async function handleHash(
           total: totalFiles,
         };
 
-    console.log(chalk.green('\n✅ Hash process finished\n'));
-    console.log(chalk.bold('📊 Final Report:'));
-    console.log(
-      `  Total JSON files scanned:    ${finalMetrics.total || totalFiles}`
-    );
-    console.log(`  Files skipped: ${finalMetrics.skipped || 0}`);
-    console.log(`  Processing errors: ${finalMetrics.errors || 0}`);
-    console.log(`  Successfully processed:  ${finalMetrics.processed || 0}`);
+    if (!options.silent) {
+      console.log(chalk.green('\n✅ Hash process finished\n'));
+      console.log(chalk.bold('📊 Final Report:'));
+      console.log(
+        `  Total JSON files scanned:    ${finalMetrics.total || totalFiles}`
+      );
+      console.log(`  Files skipped: ${finalMetrics.skipped || 0}`);
+      console.log(`  Processing errors: ${finalMetrics.errors || 0}`);
+      console.log(`  Successfully processed:  ${finalMetrics.processed || 0}`);
 
-    const totalHandled =
-      (finalMetrics.skipped || 0) +
-      (finalMetrics.errors || 0) +
-      (finalMetrics.processed || 0);
+      const totalHandled =
+        (finalMetrics.skipped || 0) +
+        (finalMetrics.errors || 0) +
+        (finalMetrics.processed || 0);
 
-    console.log(`  Total files handled:    ${totalHandled}`);
+      console.log(`  Total files handled:    ${totalHandled}`);
 
-    const elapsed = Date.now() - finalMetrics.startTime;
-    const seconds = Math.floor(elapsed / 1000);
-    console.log(`  Duration:               ${seconds}s`);
-    console.log(`\n  Error report:   ${config.errorCsvPath}`);
-    console.log(`  Warning report: ${config.warningCsvPath}`);
-    console.log(`  Output ZIP:     ${options.outputZip}`);
-    console.log(`  Output CSV:     ${options.outputCsv}`);
+      const elapsed = Date.now() - finalMetrics.startTime;
+      const seconds = Math.floor(elapsed / 1000);
+      console.log(`  Duration:               ${seconds}s`);
+      console.log(`\n  Error report:   ${config.errorCsvPath}`);
+      console.log(`  Warning report: ${config.warningCsvPath}`);
+      console.log(`  Output ZIP:     ${options.outputZip}`);
+      console.log(`  Output CSV:     ${options.outputCsv}`);
+    }
 
     // Clean up temporary directory if it was created
     await cleanup();
@@ -692,7 +707,11 @@ export async function handleHash(
     // Clean up temporary directory if it was created
     await cleanup();
 
-    process.exit(1);
+    if (options.silent) {
+      throw error;
+    } else {
+      process.exit(1);
+    }
   }
 }
 

--- a/src/commands/hash.ts
+++ b/src/commands/hash.ts
@@ -44,6 +44,7 @@ export interface HashCommandOptions {
   maxConcurrentTasks?: number;
   propertyCid?: string;
   silent?: boolean;
+  cwd?: string;
 }
 
 export function registerHashCommand(program: Command) {
@@ -75,9 +76,13 @@ export function registerHashCommand(program: Command) {
       options.maxConcurrentTasks =
         parseInt(options.maxConcurrentTasks, 10) || undefined;
 
+      const workingDir = options.cwd || process.cwd();
       const commandOptions: HashCommandOptions = {
         ...options,
-        input: path.resolve(input),
+        input: path.resolve(workingDir, input),
+        outputZip: path.resolve(workingDir, options.outputZip),
+        outputCsv: path.resolve(workingDir, options.outputCsv),
+        cwd: workingDir,
       };
 
       await handleHash(commandOptions);

--- a/src/commands/submit-to-contract.ts
+++ b/src/commands/submit-to-contract.ts
@@ -394,9 +394,12 @@ export async function handleSubmitToContract(
   logger.technical(`Transaction batch size: ${options.transactionBatchSize}`);
   logger.technical(`Gas price: ${options.gasPrice}`);
 
-  const config = createSubmitConfig({
-    transactionBatchSize: options.transactionBatchSize,
-  });
+  const config = createSubmitConfig(
+    {
+      transactionBatchSize: options.transactionBatchSize,
+    },
+    options.cwd
+  );
 
   // Create mock services when eligibility checks are disabled, in dry-run mode, or API mode to avoid blockchain calls
   const chainStateService =

--- a/src/commands/transform/index.ts
+++ b/src/commands/transform/index.ts
@@ -93,7 +93,6 @@ export async function handleTransform(options: TransformCommandOptions) {
 }
 
 async function handleScriptsMode(options: TransformCommandOptions) {
-  console.log(`Options: ${JSON.stringify(options)}`);
   const workingDir = options.cwd || process.cwd();
   const outputZip = options.outputZip || 'transformed-data.zip';
   const resolvedOutputZip = path.resolve(workingDir, outputZip);

--- a/src/commands/transform/index.ts
+++ b/src/commands/transform/index.ts
@@ -92,6 +92,7 @@ export async function handleTransform(options: TransformCommandOptions) {
 }
 
 async function handleScriptsMode(options: TransformCommandOptions) {
+  console.log(`Options: ${JSON.stringify(options)}`);
   const outputZip = options.outputZip || 'transformed-data.zip';
   if (!options.inputZip) {
     const error = 'In scripts mode, --input-zip is required';

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -390,7 +390,7 @@ export async function handleUpload(
       }
 
       await fsPromises.writeFile(
-        options.outputCsv,
+        path.resolve(options.cwd || process.cwd(), options.outputCsv),
         csvData.join('\n'),
         'utf-8'
       );

--- a/src/commands/upload.ts
+++ b/src/commands/upload.ts
@@ -15,6 +15,7 @@ export interface UploadCommandOptions {
   pinataJwt?: string;
   outputCsv?: string;
   silent?: boolean;
+  cwd?: string;
 }
 
 export function registerUploadCommand(program: Command) {
@@ -33,10 +34,15 @@ export function registerUploadCommand(program: Command) {
       'upload-results.csv'
     )
     .action(async (input, options) => {
+      const workingDir = options.cwd || process.cwd();
       const commandOptions: UploadCommandOptions = {
         ...options,
-        input: path.resolve(input),
+        input: path.resolve(workingDir, input),
+        outputCsv: options.outputCsv
+          ? path.resolve(workingDir, options.outputCsv)
+          : path.resolve(workingDir, 'upload-results.csv'),
         pinataJwt: options.pinataJwt || process.env.PINATA_JWT,
+        cwd: workingDir,
       };
 
       if (!commandOptions.pinataJwt) {

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -102,8 +102,8 @@ export async function handleValidate(
 
   logger.technical(`Processing single property data from: ${actualInputDir}`);
   const workingDir = options.cwd || process.cwd();
-  const errorCsvPath =
-    options.outputCsv || path.resolve(workingDir, 'submit_errors.csv');
+  const erorrCsvName = options.outputCsv || 'submit_errors.csv';
+  const errorCsvPath = path.resolve(workingDir, erorrCsvName);
   logger.technical(`Output CSV: ${errorCsvPath}`);
   logger.info('Note: Processing single property data only');
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -104,6 +104,7 @@ export async function handleValidate(
   const workingDir = options.cwd || process.cwd();
   const erorrCsvName = options.outputCsv || 'submit_errors.csv';
   const errorCsvPath = path.resolve(workingDir, erorrCsvName);
+  const warningCsvPath = path.resolve(workingDir, 'submit_warnings.csv');
   logger.technical(`Output CSV: ${errorCsvPath}`);
   logger.info('Note: Processing single property data only');
 
@@ -116,6 +117,7 @@ export async function handleValidate(
 
   const config = createSubmitConfig({
     errorCsvPath,
+    warningCsvPath,
   });
 
   // Keep a reference to csvReporterService to use in the final catch block

--- a/src/config/submit.config.ts
+++ b/src/config/submit.config.ts
@@ -1,5 +1,5 @@
 import { cpus } from 'os';
-import { path } from 'path';
+import path from 'path';
 
 export interface SubmitConfig {
   // Concurrency limits
@@ -82,10 +82,22 @@ export function createSubmitConfig(
   cwd?: string
 ): SubmitConfig {
   if (cwd) {
-    overrides.errorCsvPath = path.join(cwd, overrides.errorCsvPath);
-    overrides.warningCsvPath = path.join(cwd, overrides.warningCsvPath);
-    overrides.checkpointPath = path.join(cwd, overrides.checkpointPath);
-    overrides.schemaCachePath = path.join(cwd, overrides.schemaCachePath);
+    overrides.errorCsvPath = path.join(
+      cwd,
+      overrides.errorCsvPath || DEFAULT_SUBMIT_CONFIG.errorCsvPath
+    );
+    overrides.warningCsvPath = path.join(
+      cwd,
+      overrides.warningCsvPath || DEFAULT_SUBMIT_CONFIG.warningCsvPath
+    );
+    overrides.checkpointPath = path.join(
+      cwd,
+      overrides.checkpointPath || DEFAULT_SUBMIT_CONFIG.checkpointPath
+    );
+    overrides.schemaCachePath = path.join(
+      cwd,
+      overrides.schemaCachePath || DEFAULT_SUBMIT_CONFIG.schemaCachePath
+    );
   }
   return {
     ...DEFAULT_SUBMIT_CONFIG,

--- a/src/config/submit.config.ts
+++ b/src/config/submit.config.ts
@@ -1,4 +1,5 @@
 import { cpus } from 'os';
+import { path } from 'path';
 
 export interface SubmitConfig {
   // Concurrency limits
@@ -77,8 +78,15 @@ export const DEFAULT_SUBMIT_CONFIG: SubmitConfig = {
 };
 
 export function createSubmitConfig(
-  overrides: Partial<SubmitConfig> = {}
+  overrides: Partial<SubmitConfig> = {},
+  cwd?: string
 ): SubmitConfig {
+  if (cwd) {
+    overrides.errorCsvPath = path.join(cwd, overrides.errorCsvPath);
+    overrides.warningCsvPath = path.join(cwd, overrides.warningCsvPath);
+    overrides.checkpointPath = path.join(cwd, overrides.checkpointPath);
+    overrides.schemaCachePath = path.join(cwd, overrides.schemaCachePath);
+  }
   return {
     ...DEFAULT_SUBMIT_CONFIG,
     ...overrides,

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -118,7 +118,7 @@ export async function transform(
     const transformOptions: TransformCommandOptions = {
       outputZip: options.outputZip || 'transformed-data.zip',
       scriptsZip: options.scriptsZip,
-      inputsZip: options.inputZip,
+      inputZip: options.inputZip,
       legacyMode: options.legacyMode || false,
       silent: true, // Enable silent mode for library usage
     };

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -1,0 +1,287 @@
+import {
+  handleTransform,
+  TransformCommandOptions,
+} from '../commands/transform/index.js';
+import {
+  handleValidate,
+  ValidateCommandOptions,
+} from '../commands/validate.js';
+import { handleHash, HashCommandOptions } from '../commands/hash.js';
+import { handleUpload, UploadCommandOptions } from '../commands/upload.js';
+import {
+  handleSubmitToContract,
+  SubmitToContractCommandOptions,
+} from '../commands/submit-to-contract.js';
+
+// Transform function interface
+export interface TransformOptions {
+  outputZip?: string;
+  scriptsZip?: string;
+  inputZip: string;
+  legacyMode?: boolean;
+}
+
+export interface TransformResult {
+  success: boolean;
+  outputPath: string;
+  error?: string;
+}
+
+// Validate function interface
+export interface ValidateOptions {
+  input: string;
+  outputCsv?: string;
+  maxConcurrentTasks?: number;
+}
+
+export interface ValidateResult {
+  success: boolean;
+  totalFiles: number;
+  errors: number;
+  processed: number;
+  skipped: number;
+  errorCsvPath: string;
+  error?: string;
+}
+
+// Hash function interface
+export interface HashOptions {
+  input: string;
+  outputZip?: string;
+  outputCsv?: string;
+  maxConcurrentTasks?: number;
+  propertyCid?: string;
+}
+
+export interface HashResult {
+  success: boolean;
+  outputZipPath: string;
+  outputCsvPath: string;
+  totalFiles: number;
+  processed: number;
+  errors: number;
+  error?: string;
+}
+
+// Upload function interface
+export interface UploadOptions {
+  input: string;
+  pinataJwt: string;
+  outputCsv?: string;
+}
+
+export interface UploadResult {
+  success: boolean;
+  uploadedDirectories: Array<{
+    name: string;
+    cid: string;
+    mediaCid?: string;
+  }>;
+  outputCsvPath?: string;
+  error?: string;
+}
+
+// Submit-to-Contract function interface
+export interface SubmitToContractOptions {
+  csvFile: string;
+  rpcUrl?: string;
+  contractAddress?: string;
+  privateKey?: string;
+  transactionBatchSize?: number;
+  gasPrice?: string | number;
+  dryRun?: boolean;
+  unsignedTransactionsJson?: string;
+  fromAddress?: string;
+  domain?: string;
+  apiKey?: string;
+  oracleKeyId?: string;
+  checkEligibility?: boolean;
+  transactionIdsCsv?: string;
+}
+
+export interface SubmitToContractResult {
+  success: boolean;
+  totalRecords: number;
+  eligibleItems: number;
+  skippedItems: number;
+  submittedTransactions: number;
+  totalItemsSubmitted: number;
+  transactionIdsCsvPath?: string;
+  error?: string;
+}
+
+// Transform function wrapper
+export async function transform(
+  options: TransformOptions
+): Promise<TransformResult> {
+  try {
+    const transformOptions: TransformCommandOptions = {
+      outputZip: options.outputZip || 'transformed-data.zip',
+      scriptsZip: options.scriptsZip,
+      inputsZip: options.inputZip,
+      legacyMode: options.legacyMode || false,
+      silent: true, // Enable silent mode for library usage
+    };
+
+    await handleTransform(transformOptions);
+
+    return {
+      success: true,
+      outputPath: transformOptions.outputZip!,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      outputPath: options.outputZip || 'transformed-data.zip',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Validate function wrapper
+export async function validate(
+  options: ValidateOptions
+): Promise<ValidateResult> {
+  try {
+    const validateOptions: ValidateCommandOptions = {
+      input: options.input,
+      outputCsv: options.outputCsv || 'submit_errors.csv',
+      maxConcurrentTasks: options.maxConcurrentTasks,
+      silent: true, // Enable silent mode for library usage
+    };
+
+    await handleValidate(validateOptions);
+
+    return {
+      success: true,
+      totalFiles: 0, // This would need to be returned from handleValidate
+      errors: 0,
+      processed: 0,
+      skipped: 0,
+      errorCsvPath: validateOptions.outputCsv!,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      totalFiles: 0,
+      errors: 1,
+      processed: 0,
+      skipped: 0,
+      errorCsvPath: options.outputCsv ?? 'submit_errors.csv',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Hash function wrapper
+export async function hash(options: HashOptions): Promise<HashResult> {
+  try {
+    const hashOptions: HashCommandOptions = {
+      input: options.input,
+      outputZip: options.outputZip || 'hashed-data.zip',
+      outputCsv: options.outputCsv || 'hash-results.csv',
+      maxConcurrentTasks: options.maxConcurrentTasks,
+      propertyCid: options.propertyCid,
+      silent: true, // Enable silent mode for library usage
+    };
+
+    await handleHash(hashOptions);
+
+    return {
+      success: true,
+      outputZipPath: hashOptions.outputZip,
+      outputCsvPath: hashOptions.outputCsv,
+      totalFiles: 0, // This would need to be returned from handleHash
+      processed: 0,
+      errors: 0,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      outputZipPath: options.outputZip || 'hashed-data.zip',
+      outputCsvPath: options.outputCsv || 'hash-results.csv',
+      totalFiles: 0,
+      processed: 0,
+      errors: 1,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Upload function wrapper
+export async function upload(options: UploadOptions): Promise<UploadResult> {
+  try {
+    const uploadOptions: UploadCommandOptions = {
+      input: options.input,
+      pinataJwt: options.pinataJwt,
+      outputCsv: options.outputCsv || 'upload-results.csv',
+      silent: true, // Enable silent mode for library usage
+    };
+
+    await handleUpload(uploadOptions);
+
+    return {
+      success: true,
+      uploadedDirectories: [], // This would need to be returned from handleUpload
+      outputCsvPath: uploadOptions.outputCsv,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      uploadedDirectories: [],
+      outputCsvPath: options.outputCsv || 'upload-results.csv',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+// Submit-to-Contract function wrapper
+export async function submitToContract(
+  options: SubmitToContractOptions
+): Promise<SubmitToContractResult> {
+  try {
+    const submitOptions: SubmitToContractCommandOptions = {
+      csvFile: options.csvFile,
+      rpcUrl:
+        options.rpcUrl || process.env.RPC_URL || 'https://polygon-rpc.com/',
+      contractAddress:
+        options.contractAddress ||
+        process.env.SUBMIT_CONTRACT_ADDRESS ||
+        '0x1234567890123456789012345678901234567890',
+      privateKey: options.privateKey || process.env.ELEPHANT_PRIVATE_KEY || '',
+      transactionBatchSize: options.transactionBatchSize || 200,
+      gasPrice: options.gasPrice || 30,
+      dryRun: options.dryRun || false,
+      unsignedTransactionsJson: options.unsignedTransactionsJson,
+      fromAddress: options.fromAddress,
+      domain: options.domain,
+      apiKey: options.apiKey,
+      oracleKeyId: options.oracleKeyId,
+      checkEligibility: options.checkEligibility || false,
+      transactionIdsCsv: options.transactionIdsCsv,
+      silent: true, // Enable silent mode for library usage
+    };
+
+    await handleSubmitToContract(submitOptions);
+
+    return {
+      success: true,
+      totalRecords: 0, // This would need to be returned from handleSubmitToContract
+      eligibleItems: 0,
+      skippedItems: 0,
+      submittedTransactions: 0,
+      totalItemsSubmitted: 0,
+      transactionIdsCsvPath: submitOptions.transactionIdsCsv,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      totalRecords: 0,
+      eligibleItems: 0,
+      skippedItems: 0,
+      submittedTransactions: 0,
+      totalItemsSubmitted: 0,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import {
   handleTransform,
   TransformCommandOptions,
@@ -19,6 +20,7 @@ export interface TransformOptions {
   scriptsZip?: string;
   inputZip: string;
   legacyMode?: boolean;
+  cwd?: string;
 }
 
 export interface TransformResult {
@@ -32,6 +34,7 @@ export interface ValidateOptions {
   input: string;
   outputCsv?: string;
   maxConcurrentTasks?: number;
+  cwd?: string;
 }
 
 export interface ValidateResult {
@@ -51,6 +54,7 @@ export interface HashOptions {
   outputCsv?: string;
   maxConcurrentTasks?: number;
   propertyCid?: string;
+  cwd?: string;
 }
 
 export interface HashResult {
@@ -68,6 +72,7 @@ export interface UploadOptions {
   input: string;
   pinataJwt: string;
   outputCsv?: string;
+  cwd?: string;
 }
 
 export interface UploadResult {
@@ -97,6 +102,7 @@ export interface SubmitToContractOptions {
   oracleKeyId?: string;
   checkEligibility?: boolean;
   transactionIdsCsv?: string;
+  cwd?: string;
 }
 
 export interface SubmitToContractResult {
@@ -115,24 +121,29 @@ export async function transform(
   options: TransformOptions
 ): Promise<TransformResult> {
   try {
+    const workingDir = options.cwd || process.cwd();
+    const outputZip = options.outputZip || 'transformed-data.zip';
     const transformOptions: TransformCommandOptions = {
-      outputZip: options.outputZip || 'transformed-data.zip',
+      outputZip,
       scriptsZip: options.scriptsZip,
       inputZip: options.inputZip,
       legacyMode: options.legacyMode || false,
       silent: true, // Enable silent mode for library usage
+      cwd: options.cwd,
     };
 
     await handleTransform(transformOptions);
 
     return {
       success: true,
-      outputPath: transformOptions.outputZip!,
+      outputPath: path.resolve(workingDir, outputZip),
     };
   } catch (error) {
+    const workingDir = options.cwd || process.cwd();
+    const outputZip = options.outputZip || 'transformed-data.zip';
     return {
       success: false,
-      outputPath: options.outputZip || 'transformed-data.zip',
+      outputPath: path.resolve(workingDir, outputZip),
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -143,11 +154,14 @@ export async function validate(
   options: ValidateOptions
 ): Promise<ValidateResult> {
   try {
+    const workingDir = options.cwd || process.cwd();
+    const outputCsv = options.outputCsv || 'submit_errors.csv';
     const validateOptions: ValidateCommandOptions = {
       input: options.input,
-      outputCsv: options.outputCsv || 'submit_errors.csv',
+      outputCsv,
       maxConcurrentTasks: options.maxConcurrentTasks,
       silent: true, // Enable silent mode for library usage
+      cwd: options.cwd,
     };
 
     await handleValidate(validateOptions);
@@ -158,16 +172,18 @@ export async function validate(
       errors: 0,
       processed: 0,
       skipped: 0,
-      errorCsvPath: validateOptions.outputCsv!,
+      errorCsvPath: path.resolve(workingDir, outputCsv),
     };
   } catch (error) {
+    const workingDir = options.cwd || process.cwd();
+    const outputCsv = options.outputCsv || 'submit_errors.csv';
     return {
       success: false,
       totalFiles: 0,
       errors: 1,
       processed: 0,
       skipped: 0,
-      errorCsvPath: options.outputCsv ?? 'submit_errors.csv',
+      errorCsvPath: path.resolve(workingDir, outputCsv),
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -176,30 +192,37 @@ export async function validate(
 // Hash function wrapper
 export async function hash(options: HashOptions): Promise<HashResult> {
   try {
+    const workingDir = options.cwd || process.cwd();
+    const outputZip = options.outputZip || 'hashed-data.zip';
+    const outputCsv = options.outputCsv || 'hash-results.csv';
     const hashOptions: HashCommandOptions = {
       input: options.input,
-      outputZip: options.outputZip || 'hashed-data.zip',
-      outputCsv: options.outputCsv || 'hash-results.csv',
+      outputZip,
+      outputCsv,
       maxConcurrentTasks: options.maxConcurrentTasks,
       propertyCid: options.propertyCid,
       silent: true, // Enable silent mode for library usage
+      cwd: options.cwd,
     };
 
     await handleHash(hashOptions);
 
     return {
       success: true,
-      outputZipPath: hashOptions.outputZip,
-      outputCsvPath: hashOptions.outputCsv,
+      outputZipPath: path.resolve(workingDir, outputZip),
+      outputCsvPath: path.resolve(workingDir, outputCsv),
       totalFiles: 0, // This would need to be returned from handleHash
       processed: 0,
       errors: 0,
     };
   } catch (error) {
+    const workingDir = options.cwd || process.cwd();
+    const outputZip = options.outputZip || 'hashed-data.zip';
+    const outputCsv = options.outputCsv || 'hash-results.csv';
     return {
       success: false,
-      outputZipPath: options.outputZip || 'hashed-data.zip',
-      outputCsvPath: options.outputCsv || 'hash-results.csv',
+      outputZipPath: path.resolve(workingDir, outputZip),
+      outputCsvPath: path.resolve(workingDir, outputCsv),
       totalFiles: 0,
       processed: 0,
       errors: 1,
@@ -211,11 +234,14 @@ export async function hash(options: HashOptions): Promise<HashResult> {
 // Upload function wrapper
 export async function upload(options: UploadOptions): Promise<UploadResult> {
   try {
+    const workingDir = options.cwd || process.cwd();
+    const outputCsv = options.outputCsv || 'upload-results.csv';
     const uploadOptions: UploadCommandOptions = {
       input: options.input,
       pinataJwt: options.pinataJwt,
-      outputCsv: options.outputCsv || 'upload-results.csv',
+      outputCsv,
       silent: true, // Enable silent mode for library usage
+      cwd: options.cwd,
     };
 
     await handleUpload(uploadOptions);
@@ -223,13 +249,15 @@ export async function upload(options: UploadOptions): Promise<UploadResult> {
     return {
       success: true,
       uploadedDirectories: [], // This would need to be returned from handleUpload
-      outputCsvPath: uploadOptions.outputCsv,
+      outputCsvPath: path.resolve(workingDir, outputCsv),
     };
   } catch (error) {
+    const workingDir = options.cwd || process.cwd();
+    const outputCsv = options.outputCsv || 'upload-results.csv';
     return {
       success: false,
       uploadedDirectories: [],
-      outputCsvPath: options.outputCsv || 'upload-results.csv',
+      outputCsvPath: path.resolve(workingDir, outputCsv),
       error: error instanceof Error ? error.message : String(error),
     };
   }
@@ -240,6 +268,7 @@ export async function submitToContract(
   options: SubmitToContractOptions
 ): Promise<SubmitToContractResult> {
   try {
+    const workingDir = options.cwd || process.cwd();
     const submitOptions: SubmitToContractCommandOptions = {
       csvFile: options.csvFile,
       rpcUrl:
@@ -260,6 +289,7 @@ export async function submitToContract(
       checkEligibility: options.checkEligibility || false,
       transactionIdsCsv: options.transactionIdsCsv,
       silent: true, // Enable silent mode for library usage
+      cwd: options.cwd,
     };
 
     await handleSubmitToContract(submitOptions);
@@ -271,7 +301,9 @@ export async function submitToContract(
       skippedItems: 0,
       submittedTransactions: 0,
       totalItemsSubmitted: 0,
-      transactionIdsCsvPath: submitOptions.transactionIdsCsv,
+      transactionIdsCsvPath: submitOptions.transactionIdsCsv
+        ? path.resolve(workingDir, submitOptions.transactionIdsCsv)
+        : undefined,
     };
   } catch (error) {
     return {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -276,7 +276,7 @@ export async function submitToContract(
       contractAddress:
         options.contractAddress ||
         process.env.SUBMIT_CONTRACT_ADDRESS ||
-        '0x1234567890123456789012345678901234567890',
+        '0x525E59e4DE2B51f52B9e30745a513E407652AB7c',
       privateKey: options.privateKey || process.env.ELEPHANT_PRIVATE_KEY || '',
       transactionBatchSize: options.transactionBatchSize || 200,
       gasPrice: options.gasPrice || 30,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,20 @@
+// Main exports for the Elephant CLI library
+export { transform } from './commands.js';
+export { validate } from './commands.js';
+export { hash } from './commands.js';
+export { upload } from './commands.js';
+export { submitToContract } from './commands.js';
+
+// Export types
+export type {
+  TransformOptions,
+  TransformResult,
+  ValidateOptions,
+  ValidateResult,
+  HashOptions,
+  HashResult,
+  UploadOptions,
+  UploadResult,
+  SubmitToContractOptions,
+  SubmitToContractResult,
+} from './commands.js';

--- a/tests/unit/commands/validate.test.ts
+++ b/tests/unit/commands/validate.test.ts
@@ -373,7 +373,9 @@ describe('handleValidate', () => {
     );
     expect(mockProgressTracker.increment).toHaveBeenCalledWith('errors');
     expect(logger.technical).toHaveBeenCalledWith(
-      'Validation errors will be saved to: test_errors.csv'
+      expect.stringMatching(
+        /Validation errors will be saved to: .*test_errors\.csv$/
+      )
     );
     expect(exitSpy).toHaveBeenCalledWith(1);
   });


### PR DESCRIPTION
- **feat(lib): add silent mode and programmatic API**
- **feat(transform): log options in scripts mode**
- **fix(commands): correct inputZip option name**
- **feat(cli): add cwd option for command paths**
- **refactor(validate): simplify error CSV path logic**
- **feat(validate): add warning CSV output path**
- **feat(config): add cwd option to submit config**
- **fix(config): handle undefined csv path overrides**
- **refactor(hash): pass cwd to submit config**
- **fix(upload): resolve outputCsv path before write**
- **refactor: pass cwd param to createSubmitConfig**
- **refactor: Update default contract address value**
- **test(validate): Update error file path assertion**
