### PR TITLE
Fix three code bugs

### DIFF
--- a/src/commands/transform/index.ts
+++ b/src/commands/transform/index.ts
@@ -204,6 +204,10 @@ async function generateFactSheet(tempRoot: string) {
     withFileTypes: true,
   });
   const propertySubDirs = htmlEntries.filter((entry) => entry.isDirectory());
+  if (propertySubDirs.length === 0) {
+    logger.warn('No property directories found in generated HTML output');
+    return; // Nothing to copy; skip relationship generation
+  }
   const htmlPropertyDir = path.join(htmlOutputDir, propertySubDirs[0].name);
   const htmlPropertyEntries = await fs.readdir(htmlPropertyDir, {
     withFileTypes: true,

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -81,7 +81,7 @@ export async function createBrowser(headless: boolean): Promise<Browser> {
     return await puppeteer.launch({
       ignoreDefaultArgs: ['--disable-extensions'],
       executablePath: await Chromium.executablePath(),
-      headless: 'shell',
+      headless: true,
       args: [
         ...Chromium.args,
         '--hide-scrollbars',

--- a/src/services/fact-sheet-relationship.service.ts
+++ b/src/services/fact-sheet-relationship.service.ts
@@ -266,6 +266,15 @@ export class FactSheetRelationshipService {
         await fsPromises.readFile(datagroupFile.filePath, 'utf-8')
       );
 
+      // Ensure relationships object exists to avoid runtime errors on legacy files
+      if (
+        !content.relationships ||
+        typeof content.relationships !== 'object' ||
+        Array.isArray(content.relationships)
+      ) {
+        content.relationships = {};
+      }
+
       let hasUpdates = false;
 
       // Add fact_sheet relationships for ALL classes found in classMappings


### PR DESCRIPTION
Fixes three bugs: adds null-safety for datagroup relationships, guards against empty HTML output directories, and corrects Puppeteer's headless option for Linux.

*   **Datagroup Relationship Null-Safety:** Prevents crashes when `content.relationships` is missing or malformed in legacy datagroup files by initializing it to an empty object.
*   **HTML Output Directory Guard:** Prevents crashes in `generateFactSheet` by adding an early return if no property directories are found in the generated HTML output.
*   **Puppeteer Headless Option:** Ensures reliable headless browser launch on Linux by changing `headless: 'shell'` to `headless: true`, as `'shell'` is not a valid boolean in this context.

---
<a href="https://cursor.com/background-agent?bcId=bc-1145bbba-acaf-428c-ac39-e53ffae89c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1145bbba-acaf-428c-ac39-e53ffae89c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

