### PR TITLE
feat: add support for custom browser flows via JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ prepared-site.zip
 | `--ignore-captcha`                 | Ignore CAPTCHA pages and continue processing.                                   | `false`  |
 | `--browser-flow-template <name>`   | Use a predefined browser automation template (e.g., `SEARCH_BY_PARCEL_ID`).     | None     |
 | `--browser-flow-parameters <json>` | JSON parameters for the browser flow template.                                  | None     |
+| `--browser-flow-file <path>`       | Path to custom browser flow JSON file (takes precedence over template).         | None     |
 | `--proxy <url>`                    | Proxy URL with authentication (format: `username:password@ip:port`).            | None     |
 
 ### Browser Flow Templates
@@ -253,12 +254,17 @@ Browser flow templates provide reusable automation patterns for complex county w
 
 For available templates, parameters, and detailed usage examples, see [Browser Flow Templates Documentation](./docs/browser-flow-templates.md).
 
-**Need a New Template?**
+**Need Maximum Flexibility?**
 
-If existing templates don't cover your county's website pattern, please:
+For complex, site-specific workflows that don't fit standard templates, you can define custom browser flows using JSON files. This gives you complete control over the automation sequence. See [Custom Browser Flows Documentation](./docs/custom-browser-flows.md) for detailed information and examples.
 
-1. Create a [GitHub issue](https://github.com/elephant-xyz/elephant-cli/issues) with details about the site structure
-2. Contact the development team for assistance in creating a new template
+Quick example using a custom flow:
+
+```bash
+elephant-cli prepare input.zip \
+  --output-zip output.zip \
+  --browser-flow-file my-custom-flow.json
+```
 
 To use `transform` with a browser on AWS EC2 instances you need to run Ubuntu 22.04 or later and perfrom the following steps:
 

--- a/docs/custom-browser-flows.md
+++ b/docs/custom-browser-flows.md
@@ -1,0 +1,802 @@
+# Custom Browser Flows
+
+## Overview
+
+Custom browser flows allow you to define complex, site-specific browser automation workflows without being constrained by predefined templates. You can create a JSON file that describes exactly what actions the browser should take, providing maximum flexibility for handling unique website structures.
+
+## Table of Contents
+
+- [When to Use Custom Flows](#when-to-use-custom-flows)
+- [Quick Start](#quick-start)
+- [Workflow Structure](#workflow-structure)
+- [Available Actions](#available-actions)
+- [Dynamic Values](#dynamic-values)
+- [Capture Configuration](#capture-configuration)
+- [Complete Examples](#complete-examples)
+- [Validation and Error Handling](#validation-and-error-handling)
+- [Best Practices](#best-practices)
+
+## When to Use Custom Flows
+
+Use custom browser flows when:
+
+- **Templates are too limiting**: Your workflow requires specific actions not covered by existing templates
+- **Complex multi-step interactions**: Multiple iframes, conditional clicks, or unusual navigation patterns
+- **Site-specific requirements**: The website has a unique structure that doesn't fit standard patterns
+- **Precise control needed**: You need exact control over timing, selectors, and action sequences
+
+Consider using [browser flow templates](./browser-flow-templates.md) when your use case fits a standard pattern, as they provide simpler parameter-based configuration.
+
+## Quick Start
+
+### 1. Create a workflow JSON file
+
+```json
+{
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}",
+        "timeout": 30000,
+        "wait_until": "domcontentloaded"
+      },
+      "next": "enter_parcel_id"
+    },
+    "enter_parcel_id": {
+      "type": "type",
+      "input": {
+        "selector": "#parcel-search",
+        "value": "{{=it.request_identifier}}",
+        "delay": 100
+      },
+      "next": "press_enter"
+    },
+    "press_enter": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
+      },
+      "next": "wait_for_results"
+    },
+    "wait_for_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "#property-details",
+        "timeout": 60000,
+        "visible": true
+      },
+      "end": true
+    }
+  }
+}
+```
+
+### 2. Use it with the prepare command
+
+```bash
+npx elephant-cli prepare input.zip \
+  --output-zip output.zip \
+  --browser-flow-file workflow.json
+```
+
+## Workflow Structure
+
+A workflow is a JSON object with the following top-level properties:
+
+```typescript
+{
+  "starts_at": "state_name",        // Required: Initial state to execute
+  "states": {                        // Required: Map of state definitions
+    "state_name": { ... }
+  },
+  "capture": {                       // Optional: Content capture configuration
+    "type": "page" | "iframe",
+    "selector": "iframe_selector"    // Required when type is "iframe"
+  }
+}
+```
+
+### State Definition
+
+Each state represents a single action and has this structure:
+
+```typescript
+{
+  "type": "action_type",             // Required: Type of action to perform
+  "input": { ... },                  // Required: Action-specific parameters
+  "next": "next_state_name",         // Optional: Next state to execute
+  "result": "variable_name",         // Optional: Store result in variable
+  "end": true                        // Optional: Mark this as final state
+}
+```
+
+**Important**: Either `next` or `end: true` must be specified (or both, where `end` takes precedence).
+
+## Available Actions
+
+### open_page
+
+Navigate to a URL.
+
+```json
+{
+  "type": "open_page",
+  "input": {
+    "url": "https://example.com",                    // Required
+    "timeout": 30000,                                 // Optional (default: 30000ms)
+    "wait_until": "domcontentloaded"                 // Optional (default: domcontentloaded)
+  }
+}
+```
+
+**wait_until options**: `load`, `domcontentloaded`, `networkidle0`, `networkidle2`
+
+### wait_for_selector
+
+Wait for an element to appear.
+
+```json
+{
+  "type": "wait_for_selector",
+  "input": {
+    "selector": "#element-id",                       // Required: CSS selector
+    "timeout": 60000,                                // Optional (default: 30000ms)
+    "visible": true,                                 // Optional (default: false)
+    "iframe_selector": "#iframe-id"                  // Optional: Selector for iframe context
+  }
+}
+```
+
+### click
+
+Click an element.
+
+```json
+{
+  "type": "click",
+  "input": {
+    "selector": "button.submit",                     // Required: CSS selector
+    "iframe_selector": "#iframe-id"                  // Optional: Selector for iframe context
+  }
+}
+```
+
+### type
+
+Type text into an input field.
+
+```json
+{
+  "type": "type",
+  "input": {
+    "selector": "input#search",                      // Required: CSS selector
+    "value": "text to type",                         // Required: Text to type
+    "delay": 100,                                    // Optional: Delay between keystrokes (ms)
+    "iframe_selector": "#iframe-id"                  // Optional: Selector for iframe context
+  }
+}
+```
+
+### keyboard_press
+
+Press a keyboard key.
+
+```json
+{
+  "type": "keyboard_press",
+  "input": {
+    "key": "Enter"                                   // Required: Key to press
+  }
+}
+```
+
+**Common keys**: `Enter`, `Tab`, `Escape`, `ArrowDown`, `ArrowUp`, `Backspace`
+
+## Dynamic Values
+
+You can use template syntax to inject runtime values into your workflow:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{=it.request_identifier}}` | Parcel ID from input data | `"12-34-56-789"` |
+| `{{=it.url}}` | URL from `source_http_request` | `"https://example.com/search"` |
+| `{{=it.variable_name}}` | Stored result from previous state | Depends on state |
+
+### Storing and Using Results
+
+Use the `result` field to store values from `wait_for_selector` actions:
+
+```json
+{
+  "states": {
+    "find_button": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "button.continue"
+      },
+      "result": "continue_button",                   // Store selector
+      "next": "click_button"
+    },
+    "click_button": {
+      "type": "click",
+      "input": {
+        "selector": "{{=it.continue_button}}"        // Use stored value
+      },
+      "end": true
+    }
+  }
+}
+```
+
+## Capture Configuration
+
+Control what content is captured at the end of the workflow:
+
+### Capture Entire Page (Default)
+
+```json
+{
+  "capture": {
+    "type": "page"
+  }
+}
+```
+
+Or omit the `capture` field entirely - page capture is the default.
+
+### Capture from IFrame
+
+```json
+{
+  "capture": {
+    "type": "iframe",
+    "selector": "#main-content-frame"
+  }
+}
+```
+
+## Complete Examples
+
+### Example 1: Simple Search Flow
+
+Basic parcel ID search with direct URL navigation:
+
+```json
+{
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}",
+        "timeout": 30000
+      },
+      "next": "enter_parcel"
+    },
+    "enter_parcel": {
+      "type": "type",
+      "input": {
+        "selector": "input#parcel-id",
+        "value": "{{=it.request_identifier}}",
+        "delay": 50
+      },
+      "next": "submit_search"
+    },
+    "submit_search": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
+      },
+      "next": "wait_results"
+    },
+    "wait_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "div.property-details",
+        "timeout": 60000,
+        "visible": true
+      },
+      "end": true
+    }
+  }
+}
+```
+
+### Example 2: Multi-Step with Disclaimer Buttons
+
+Handle two disclaimer screens before searching:
+
+```json
+{
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}"
+      },
+      "next": "wait_first_disclaimer"
+    },
+    "wait_first_disclaimer": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "button#accept-terms",
+        "timeout": 15000,
+        "visible": true
+      },
+      "next": "click_first_disclaimer"
+    },
+    "click_first_disclaimer": {
+      "type": "click",
+      "input": {
+        "selector": "button#accept-terms"
+      },
+      "next": "wait_second_disclaimer"
+    },
+    "wait_second_disclaimer": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "button#continue",
+        "timeout": 15000,
+        "visible": true
+      },
+      "next": "click_second_disclaimer"
+    },
+    "click_second_disclaimer": {
+      "type": "click",
+      "input": {
+        "selector": "button#continue"
+      },
+      "next": "wait_search_form"
+    },
+    "wait_search_form": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "input#search",
+        "timeout": 30000,
+        "visible": true
+      },
+      "next": "enter_parcel"
+    },
+    "enter_parcel": {
+      "type": "type",
+      "input": {
+        "selector": "input#search",
+        "value": "{{=it.request_identifier}}"
+      },
+      "next": "submit"
+    },
+    "submit": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
+      },
+      "next": "wait_results"
+    },
+    "wait_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "div.results",
+        "timeout": 60000,
+        "visible": true
+      },
+      "end": true
+    }
+  }
+}
+```
+
+### Example 3: Working with IFrames
+
+Search within an iframe and capture its content:
+
+```json
+{
+  "starts_at": "open_page",
+  "capture": {
+    "type": "iframe",
+    "selector": "iframe#search-frame"
+  },
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}"
+      },
+      "next": "wait_iframe"
+    },
+    "wait_iframe": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "iframe#search-frame",
+        "timeout": 30000
+      },
+      "next": "enter_parcel"
+    },
+    "enter_parcel": {
+      "type": "type",
+      "input": {
+        "selector": "input#parcel-search",
+        "value": "{{=it.request_identifier}}",
+        "iframe_selector": "iframe#search-frame"
+      },
+      "next": "submit"
+    },
+    "submit": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
+      },
+      "next": "wait_results"
+    },
+    "wait_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "table.results",
+        "timeout": 60000,
+        "visible": true,
+        "iframe_selector": "iframe#search-frame"
+      },
+      "end": true
+    }
+  }
+}
+```
+
+### Example 4: Click Through to Details Page
+
+Search, then click on the first result to view details:
+
+```json
+{
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}"
+      },
+      "next": "enter_parcel"
+    },
+    "enter_parcel": {
+      "type": "type",
+      "input": {
+        "selector": "input#search",
+        "value": "{{=it.request_identifier}}"
+      },
+      "next": "submit"
+    },
+    "submit": {
+      "type": "keyboard_press",
+      "input": {
+        "key": "Enter"
+      },
+      "next": "wait_results"
+    },
+    "wait_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "table.results tbody tr",
+        "timeout": 60000,
+        "visible": true
+      },
+      "next": "click_first_result"
+    },
+    "click_first_result": {
+      "type": "click",
+      "input": {
+        "selector": "table.results tbody tr:first-child td:nth-child(2)"
+      },
+      "next": "wait_details"
+    },
+    "wait_details": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "#property-details",
+        "timeout": 60000,
+        "visible": true
+      },
+      "end": true
+    }
+  }
+}
+```
+
+### Example 5: Multiple IFrames
+
+Navigate through nested iframes:
+
+```json
+{
+  "starts_at": "open_page",
+  "capture": {
+    "type": "iframe",
+    "selector": "iframe#content-frame"
+  },
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": {
+        "url": "{{=it.url}}"
+      },
+      "next": "click_disclaimer"
+    },
+    "click_disclaimer": {
+      "type": "click",
+      "input": {
+        "selector": "button#accept"
+      },
+      "next": "wait_search_iframe"
+    },
+    "wait_search_iframe": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "iframe#search-frame",
+        "timeout": 30000
+      },
+      "next": "enter_search"
+    },
+    "enter_search": {
+      "type": "type",
+      "input": {
+        "selector": "input#query",
+        "value": "{{=it.request_identifier}}",
+        "iframe_selector": "iframe#search-frame"
+      },
+      "next": "submit"
+    },
+    "submit": {
+      "type": "click",
+      "input": {
+        "selector": "button#search-btn",
+        "iframe_selector": "iframe#search-frame"
+      },
+      "next": "wait_results"
+    },
+    "wait_results": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "table.results",
+        "timeout": 60000,
+        "visible": true,
+        "iframe_selector": "iframe#search-frame"
+      },
+      "next": "click_result"
+    },
+    "click_result": {
+      "type": "click",
+      "input": {
+        "selector": "table.results tr:first-child",
+        "iframe_selector": "iframe#search-frame"
+      },
+      "next": "wait_content_iframe"
+    },
+    "wait_content_iframe": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "iframe#content-frame",
+        "timeout": 30000
+      },
+      "next": "wait_property_details"
+    },
+    "wait_property_details": {
+      "type": "wait_for_selector",
+      "input": {
+        "selector": "#property-info",
+        "timeout": 60000,
+        "visible": true,
+        "iframe_selector": "iframe#content-frame"
+      },
+      "end": true
+    }
+  }
+}
+```
+
+## Validation and Error Handling
+
+### Validation Rules
+
+The workflow is validated before execution:
+
+1. **Required fields**: `starts_at` and `states` must be present
+2. **State references**: All `next` and `starts_at` must reference existing states
+3. **Action types**: Must be one of the valid action types
+4. **Input parameters**: Each action type has required and optional parameters
+5. **Flow completion**: At least one state must have `end: true` or be a terminal state
+6. **Capture config**: If type is `iframe`, selector must be provided
+
+### Common Validation Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `starts_at references unknown state` | The initial state name doesn't exist | Check state name spelling |
+| `next references unknown state` | A `next` field points to non-existent state | Verify all state names |
+| `input.url must be a non-empty string` | Missing or empty URL in `open_page` | Provide valid URL |
+| `selector must be a non-empty string` | Empty selector | Provide valid CSS selector |
+| `states must contain at least one state` | Empty states object | Add at least one state |
+
+### Runtime Errors
+
+If the workflow fails during execution:
+
+- **Timeout errors**: Increase timeout values for slow-loading elements
+- **Selector not found**: Verify selectors using browser dev tools
+- **IFrame errors**: Ensure iframe exists before trying to access it
+- **Navigation errors**: Check URL validity and network connectivity
+
+## Best Practices
+
+### 1. Use Descriptive State Names
+
+```json
+// Good
+"wait_for_disclaimer_button"
+"click_accept_terms"
+"enter_parcel_id"
+
+// Bad
+"step1"
+"action2"
+"wait1"
+```
+
+### 2. Set Appropriate Timeouts
+
+```json
+// Short timeout for expected elements
+"timeout": 10000
+
+// Longer timeout for search results or slow operations
+"timeout": 60000
+```
+
+### 3. Mark Elements as Visible When Needed
+
+```json
+{
+  "type": "wait_for_selector",
+  "input": {
+    "selector": "button#submit",
+    "visible": true  // Ensures button is actually visible, not just in DOM
+  }
+}
+```
+
+### 4. Use IFrame Selectors Consistently
+
+When working with iframes, always specify `iframe_selector` for all actions within that iframe:
+
+```json
+// All actions on elements inside the iframe need iframe_selector
+{
+  "type": "type",
+  "input": {
+    "selector": "#input",
+    "iframe_selector": "#main-frame"  // ✓ Correct
+  }
+}
+```
+
+### 5. Test Selectors First
+
+Before creating your workflow, test selectors in browser console:
+
+```javascript
+// Main page
+document.querySelector('#your-selector')
+
+// Inside iframe
+document.querySelector('iframe#frame-selector').contentDocument.querySelector('#element')
+```
+
+### 6. Keep Workflows Readable
+
+Use proper JSON formatting and organize complex workflows with comments (in a separate doc):
+
+```json
+{
+  "starts_at": "open_page",
+  "states": {
+    "open_page": {
+      "type": "open_page",
+      "input": { "url": "{{=it.url}}" },
+      "next": "handle_disclaimer"
+    },
+
+    "handle_disclaimer": {
+      "type": "click",
+      "input": { "selector": "#accept" },
+      "next": "enter_search"
+    }
+  }
+}
+```
+
+### 7. Handle Different Capture Scenarios
+
+Choose the right capture configuration:
+
+```json
+// Capture main page (default)
+"capture": { "type": "page" }
+
+// Capture specific iframe with results
+"capture": { "type": "iframe", "selector": "#results-frame" }
+```
+
+### 8. Debug with Non-Headless Mode
+
+Test your workflow visually:
+
+```bash
+npx elephant-cli prepare input.zip \
+  --output-zip output.zip \
+  --browser-flow-file workflow.json \
+  --no-headless
+```
+
+### 9. Version Control Your Workflows
+
+Store workflow files in version control with meaningful names:
+
+```
+workflows/
+  ├── county-a-search.json
+  ├── county-b-with-disclaimers.json
+  └── county-c-iframe-search.json
+```
+
+### 10. Document Site-Specific Requirements
+
+Keep notes about why certain steps are needed:
+
+```
+workflow-notes.md:
+- County X requires 2 disclaimer clicks before search
+- Results are in nested iframe #content > #results
+- Must wait for visible: true on search button (it's hidden initially)
+```
+
+## Troubleshooting
+
+### Workflow Doesn't Execute
+
+1. **Check validation**: Run the command and look for validation errors
+2. **Verify JSON**: Ensure your JSON is valid (use a JSON validator)
+3. **Check file path**: Make sure the path to your workflow file is correct
+
+### Elements Not Found
+
+1. **Test selectors**: Use browser dev tools to verify selectors
+2. **Check timing**: Element might not be loaded yet - increase timeout
+3. **IFrame context**: If element is in iframe, add `iframe_selector`
+4. **Visibility**: Try adding `"visible": true` to wait_for_selector
+
+### Capture Returns Wrong Content
+
+1. **Check capture config**: Verify you're capturing from the right source
+2. **Wait for content**: Ensure the final state waits for all content to load
+3. **IFrame timing**: When capturing from iframe, ensure it's fully loaded
+
+### Timeout Errors
+
+1. **Increase timeouts**: Some sites are slow to respond
+2. **Check network**: Verify the site is accessible
+3. **Simplify workflow**: Test each step individually to isolate the issue
+
+## Getting Help
+
+If you encounter issues:
+
+1. Review this documentation and examples
+2. Test your selectors in browser dev tools
+3. Run with `--no-headless` to visually debug
+4. Enable debug logging: `LOG_LEVEL=debug npx elephant-cli prepare ...`
+5. Check validation error messages for specific issues
+
+For more information on browser flows, see:
+- [Browser Flow Templates](./browser-flow-templates.md) - Pre-built template options
+- [README](../README.md) - General CLI documentation

--- a/src/commands/prepare/index.ts
+++ b/src/commands/prepare/index.ts
@@ -15,6 +15,7 @@ export interface PrepareCommandOptions {
   headless?: boolean;
   browserFlowTemplate?: string;
   browserFlowParameters?: string;
+  browserFlowFile?: string;
   ignoreCaptcha?: boolean;
   proxy?: ProxyUrl;
 }
@@ -40,6 +41,10 @@ export function registerPrepareCommand(program: Command) {
     .option(
       '--browser-flow-parameters <json>',
       'JSON parameters for the browser flow template'
+    )
+    .option(
+      '--browser-flow-file <path>',
+      'Path to custom browser flow JSON file (takes precedence over template)'
     )
     .option(
       '--ignore-captcha',
@@ -69,6 +74,7 @@ export async function handlePrepare(
     headless: options.headless,
     browserFlowTemplate: options.browserFlowTemplate,
     browserFlowParameters: options.browserFlowParameters,
+    browserFlowFile: options.browserFlowFile,
     ignoreCaptcha: options.ignoreCaptcha,
     proxy: options.proxy,
   });

--- a/src/lib/browser-flow/customFlow.ts
+++ b/src/lib/browser-flow/customFlow.ts
@@ -1,0 +1,334 @@
+import { promises as fs } from 'fs';
+import { Workflow } from '../withBrowserFlow.js';
+import { logger } from '../../utils/logger.js';
+
+export interface CustomFlowValidationResult {
+  valid: boolean;
+  errors?: string[];
+}
+
+function isValidWaitUntil(value: unknown): boolean {
+  const validValues = [
+    'load',
+    'domcontentloaded',
+    'networkidle0',
+    'networkidle2',
+  ];
+  return typeof value === 'string' && validValues.includes(value);
+}
+
+function isValidNodeType(value: unknown): boolean {
+  const validTypes = [
+    'open_page',
+    'wait_for_selector',
+    'click',
+    'type',
+    'keyboard_press',
+  ];
+  return typeof value === 'string' && validTypes.includes(value);
+}
+
+function validateOpenPageInput(input: unknown): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') {
+    errors.push('open_page input must be an object');
+    return errors;
+  }
+
+  const inputObj = input as Record<string, unknown>;
+
+  if (typeof inputObj.url !== 'string' || inputObj.url.length === 0) {
+    errors.push('open_page input.url must be a non-empty string');
+  }
+
+  if (inputObj.timeout !== undefined && typeof inputObj.timeout !== 'number') {
+    errors.push('open_page input.timeout must be a number');
+  }
+
+  if (
+    inputObj.wait_until !== undefined &&
+    !isValidWaitUntil(inputObj.wait_until)
+  ) {
+    errors.push(
+      'open_page input.wait_until must be one of: load, domcontentloaded, networkidle0, networkidle2'
+    );
+  }
+
+  return errors;
+}
+
+function validateWaitForSelectorInput(input: unknown): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') {
+    errors.push('wait_for_selector input must be an object');
+    return errors;
+  }
+
+  const inputObj = input as Record<string, unknown>;
+
+  if (typeof inputObj.selector !== 'string' || inputObj.selector.length === 0) {
+    errors.push('wait_for_selector input.selector must be a non-empty string');
+  }
+
+  if (inputObj.timeout !== undefined && typeof inputObj.timeout !== 'number') {
+    errors.push('wait_for_selector input.timeout must be a number');
+  }
+
+  if (inputObj.visible !== undefined && typeof inputObj.visible !== 'boolean') {
+    errors.push('wait_for_selector input.visible must be a boolean');
+  }
+
+  if (
+    inputObj.iframe_selector !== undefined &&
+    typeof inputObj.iframe_selector !== 'string'
+  ) {
+    errors.push('wait_for_selector input.iframe_selector must be a string');
+  }
+
+  return errors;
+}
+
+function validateClickInput(input: unknown): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') {
+    errors.push('click input must be an object');
+    return errors;
+  }
+
+  const inputObj = input as Record<string, unknown>;
+
+  if (typeof inputObj.selector !== 'string' || inputObj.selector.length === 0) {
+    errors.push('click input.selector must be a non-empty string');
+  }
+
+  if (
+    inputObj.iframe_selector !== undefined &&
+    typeof inputObj.iframe_selector !== 'string'
+  ) {
+    errors.push('click input.iframe_selector must be a string');
+  }
+
+  return errors;
+}
+
+function validateTypeInput(input: unknown): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') {
+    errors.push('type input must be an object');
+    return errors;
+  }
+
+  const inputObj = input as Record<string, unknown>;
+
+  if (typeof inputObj.selector !== 'string' || inputObj.selector.length === 0) {
+    errors.push('type input.selector must be a non-empty string');
+  }
+
+  if (typeof inputObj.value !== 'string') {
+    errors.push('type input.value must be a string');
+  }
+
+  if (inputObj.delay !== undefined && typeof inputObj.delay !== 'number') {
+    errors.push('type input.delay must be a number');
+  }
+
+  if (
+    inputObj.iframe_selector !== undefined &&
+    typeof inputObj.iframe_selector !== 'string'
+  ) {
+    errors.push('type input.iframe_selector must be a string');
+  }
+
+  return errors;
+}
+
+function validateKeyboardPressInput(input: unknown): string[] {
+  const errors: string[] = [];
+  if (!input || typeof input !== 'object') {
+    errors.push('keyboard_press input must be an object');
+    return errors;
+  }
+
+  const inputObj = input as Record<string, unknown>;
+
+  if (typeof inputObj.key !== 'string' || inputObj.key.length === 0) {
+    errors.push('keyboard_press input.key must be a non-empty string');
+  }
+
+  return errors;
+}
+
+function validateNode(
+  stateName: string,
+  node: unknown,
+  allStateNames: string[]
+): string[] {
+  const errors: string[] = [];
+
+  if (!node || typeof node !== 'object') {
+    errors.push(`State "${stateName}": node must be an object`);
+    return errors;
+  }
+
+  const nodeObj = node as Record<string, unknown>;
+
+  if (!isValidNodeType(nodeObj.type)) {
+    errors.push(
+      `State "${stateName}": type must be one of: open_page, wait_for_selector, click, type, keyboard_press`
+    );
+    return errors;
+  }
+
+  if (!nodeObj.input) {
+    errors.push(`State "${stateName}": input is required`);
+  }
+
+  const type = nodeObj.type as string;
+  switch (type) {
+    case 'open_page':
+      errors.push(...validateOpenPageInput(nodeObj.input));
+      break;
+    case 'wait_for_selector':
+      errors.push(...validateWaitForSelectorInput(nodeObj.input));
+      break;
+    case 'click':
+      errors.push(...validateClickInput(nodeObj.input));
+      break;
+    case 'type':
+      errors.push(...validateTypeInput(nodeObj.input));
+      break;
+    case 'keyboard_press':
+      errors.push(...validateKeyboardPressInput(nodeObj.input));
+      break;
+  }
+
+  if (nodeObj.next !== undefined) {
+    if (typeof nodeObj.next !== 'string') {
+      errors.push(`State "${stateName}": next must be a string`);
+    }
+    if (
+      typeof nodeObj.next === 'string' &&
+      !allStateNames.includes(nodeObj.next)
+    ) {
+      errors.push(
+        `State "${stateName}": next references unknown state "${nodeObj.next}"`
+      );
+    }
+  }
+
+  if (nodeObj.result !== undefined && typeof nodeObj.result !== 'string') {
+    errors.push(`State "${stateName}": result must be a string`);
+  }
+
+  if (nodeObj.end !== undefined && typeof nodeObj.end !== 'boolean') {
+    errors.push(`State "${stateName}": end must be a boolean`);
+  }
+
+  return errors;
+}
+
+function validateCaptureConfig(capture: unknown): string[] {
+  const errors: string[] = [];
+
+  if (!capture) return errors;
+
+  if (typeof capture !== 'object') {
+    errors.push('capture must be an object');
+    return errors;
+  }
+
+  const captureObj = capture as Record<string, unknown>;
+
+  if (typeof captureObj.type !== 'string') {
+    errors.push('capture.type must be a string');
+    return errors;
+  }
+
+  if (captureObj.type !== 'page' && captureObj.type !== 'iframe') {
+    errors.push('capture.type must be either "page" or "iframe"');
+  }
+
+  if (captureObj.type === 'iframe') {
+    if (
+      typeof captureObj.selector !== 'string' ||
+      captureObj.selector.length === 0
+    ) {
+      errors.push(
+        'capture.selector must be a non-empty string when type is "iframe"'
+      );
+    }
+  }
+
+  return errors;
+}
+
+export function validateCustomFlow(
+  workflow: unknown
+): CustomFlowValidationResult {
+  const errors: string[] = [];
+
+  if (!workflow || typeof workflow !== 'object') {
+    return {
+      valid: false,
+      errors: ['Workflow must be an object'],
+    };
+  }
+
+  const workflowObj = workflow as Record<string, unknown>;
+
+  if (typeof workflowObj.starts_at !== 'string') {
+    errors.push('starts_at must be a string');
+  }
+
+  if (!workflowObj.states || typeof workflowObj.states !== 'object') {
+    errors.push('states must be an object');
+    return { valid: false, errors };
+  }
+
+  const states = workflowObj.states as Record<string, unknown>;
+  const stateNames = Object.keys(states);
+
+  if (stateNames.length === 0) {
+    errors.push('states must contain at least one state');
+  }
+
+  if (
+    typeof workflowObj.starts_at === 'string' &&
+    !stateNames.includes(workflowObj.starts_at)
+  ) {
+    errors.push(
+      `starts_at references unknown state "${workflowObj.starts_at}"`
+    );
+  }
+
+  for (const [stateName, node] of Object.entries(states)) {
+    const nodeErrors = validateNode(stateName, node, stateNames);
+    errors.push(...nodeErrors.map((err) => `State "${stateName}": ${err}`));
+  }
+
+  if (workflowObj.capture !== undefined) {
+    errors.push(...validateCaptureConfig(workflowObj.capture));
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors: errors.length > 0 ? errors : undefined,
+  };
+}
+
+export async function loadCustomFlow(filePath: string): Promise<Workflow> {
+  logger.info(`Loading custom browser flow from: ${filePath}`);
+
+  const content = await fs.readFile(filePath, 'utf-8');
+  const workflow: unknown = JSON.parse(content);
+
+  const validation = validateCustomFlow(workflow);
+  if (!validation.valid) {
+    logger.error('Custom browser flow validation failed:');
+    validation.errors?.forEach((error) => logger.error(`  - ${error}`));
+    throw new Error('Invalid custom browser flow definition');
+  }
+
+  logger.info('Custom browser flow loaded and validated successfully');
+  return workflow as Workflow;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -18,6 +18,7 @@ export type PrepareOptions = {
   errorPatterns?: string[];
   browserFlowTemplate?: string;
   browserFlowParameters?: string;
+  browserFlowFile?: string;
   ignoreCaptcha?: boolean;
   proxy?: ProxyUrl;
 };

--- a/tests/lib/browser-flow/customFlow.test.ts
+++ b/tests/lib/browser-flow/customFlow.test.ts
@@ -1,0 +1,423 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  validateCustomFlow,
+  loadCustomFlow,
+} from '../../../src/lib/browser-flow/customFlow.js';
+import { promises as fs } from 'fs';
+import { Workflow } from '../../../src/lib/withBrowserFlow.js';
+
+vi.mock('fs', () => ({
+  promises: {
+    readFile: vi.fn(),
+  },
+}));
+
+describe('Custom Browser Flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('validateCustomFlow', () => {
+    it('should validate a valid workflow', () => {
+      const workflow: Workflow = {
+        starts_at: 'open_page',
+        states: {
+          open_page: {
+            type: 'open_page',
+            input: {
+              url: 'https://example.com',
+              timeout: 30000,
+              wait_until: 'domcontentloaded',
+            },
+            next: 'wait_for_element',
+          },
+          wait_for_element: {
+            type: 'wait_for_selector',
+            input: {
+              selector: '#content',
+              timeout: 10000,
+              visible: true,
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+
+    it('should validate workflow with capture config', () => {
+      const workflow: Workflow = {
+        starts_at: 'open_page',
+        capture: {
+          type: 'iframe',
+          selector: '#main-iframe',
+        },
+        states: {
+          open_page: {
+            type: 'open_page',
+            input: {
+              url: 'https://example.com',
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(true);
+    });
+
+    it('should reject non-object workflow', () => {
+      const result = validateCustomFlow('not an object');
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('Workflow must be an object');
+    });
+
+    it('should reject workflow without starts_at', () => {
+      const workflow = {
+        states: {
+          test: {
+            type: 'open_page',
+            input: { url: 'https://example.com' },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('starts_at must be a string');
+    });
+
+    it('should reject workflow with invalid starts_at reference', () => {
+      const workflow = {
+        starts_at: 'non_existent_state',
+        states: {
+          test: {
+            type: 'open_page',
+            input: { url: 'https://example.com' },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'starts_at references unknown state "non_existent_state"'
+      );
+    });
+
+    it('should reject workflow without states', () => {
+      const workflow = {
+        starts_at: 'test',
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('states must be an object');
+    });
+
+    it('should reject workflow with empty states', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {},
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain('states must contain at least one state');
+    });
+
+    it('should reject state with invalid type', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'invalid_type',
+            input: {},
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain(
+        'type must be one of: open_page, wait_for_selector, click, type, keyboard_press'
+      );
+    });
+
+    it('should reject state with invalid next reference', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'open_page',
+            input: { url: 'https://example.com' },
+            next: 'non_existent',
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain(
+        'next references unknown state "non_existent"'
+      );
+    });
+
+    it('should validate open_page input', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'open_page',
+            input: {
+              url: '',
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain('url must be a non-empty string');
+    });
+
+    it('should validate wait_for_selector input', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'wait_for_selector',
+            input: {
+              selector: '',
+              timeout: 'not a number',
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.some((e) => e.includes('selector'))).toBe(true);
+      expect(result.errors!.some((e) => e.includes('timeout'))).toBe(true);
+    });
+
+    it('should validate click input', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'click',
+            input: {
+              selector: 123,
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain(
+        'selector must be a non-empty string'
+      );
+    });
+
+    it('should validate type input', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'type',
+            input: {
+              selector: '#input',
+              value: 123,
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain('value must be a string');
+    });
+
+    it('should validate keyboard_press input', () => {
+      const workflow = {
+        starts_at: 'test',
+        states: {
+          test: {
+            type: 'keyboard_press',
+            input: {
+              key: '',
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors?.[0]).toContain('key must be a non-empty string');
+    });
+
+    it('should validate capture config with invalid type', () => {
+      const workflow = {
+        starts_at: 'test',
+        capture: {
+          type: 'invalid',
+        },
+        states: {
+          test: {
+            type: 'open_page',
+            input: { url: 'https://example.com' },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'capture.type must be either "page" or "iframe"'
+      );
+    });
+
+    it('should validate iframe capture requires selector', () => {
+      const workflow = {
+        starts_at: 'test',
+        capture: {
+          type: 'iframe',
+        },
+        states: {
+          test: {
+            type: 'open_page',
+            input: { url: 'https://example.com' },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContain(
+        'capture.selector must be a non-empty string when type is "iframe"'
+      );
+    });
+
+    it('should validate complex workflow with all node types', () => {
+      const workflow: Workflow = {
+        starts_at: 'open_page',
+        capture: { type: 'page' },
+        states: {
+          open_page: {
+            type: 'open_page',
+            input: {
+              url: 'https://example.com',
+              timeout: 30000,
+              wait_until: 'networkidle0',
+            },
+            next: 'wait_for_button',
+          },
+          wait_for_button: {
+            type: 'wait_for_selector',
+            input: {
+              selector: '#continue-btn',
+              timeout: 10000,
+              visible: true,
+              iframe_selector: '#main-frame',
+            },
+            next: 'click_button',
+          },
+          click_button: {
+            type: 'click',
+            input: {
+              selector: '#continue-btn',
+              iframe_selector: '#main-frame',
+            },
+            next: 'type_search',
+          },
+          type_search: {
+            type: 'type',
+            input: {
+              selector: '#search-input',
+              value: 'test query',
+              delay: 50,
+            },
+            next: 'press_enter',
+          },
+          press_enter: {
+            type: 'keyboard_press',
+            input: {
+              key: 'Enter',
+            },
+            end: true,
+          },
+        },
+      };
+
+      const result = validateCustomFlow(workflow);
+      expect(result.valid).toBe(true);
+      expect(result.errors).toBeUndefined();
+    });
+  });
+
+  describe('loadCustomFlow', () => {
+    it('should load and validate a valid workflow from file', async () => {
+      const workflow: Workflow = {
+        starts_at: 'open_page',
+        states: {
+          open_page: {
+            type: 'open_page',
+            input: {
+              url: 'https://example.com',
+            },
+            end: true,
+          },
+        },
+      };
+
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(workflow));
+
+      const result = await loadCustomFlow('/path/to/workflow.json');
+      expect(result).toEqual(workflow);
+      expect(fs.readFile).toHaveBeenCalledWith(
+        '/path/to/workflow.json',
+        'utf-8'
+      );
+    });
+
+    it('should throw error for invalid JSON', async () => {
+      vi.mocked(fs.readFile).mockResolvedValue('invalid json');
+
+      await expect(loadCustomFlow('/path/to/invalid.json')).rejects.toThrow();
+    });
+
+    it('should throw error for invalid workflow structure', async () => {
+      const invalidWorkflow = {
+        starts_at: 'missing_state',
+        states: {},
+      };
+
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(invalidWorkflow));
+
+      await expect(loadCustomFlow('/path/to/invalid.json')).rejects.toThrow(
+        'Invalid custom browser flow definition'
+      );
+    });
+  });
+});


### PR DESCRIPTION
- Introduced `--browser-flow-file` option in the CLI for specifying custom browser flow JSON files.
- Implemented validation for custom workflows to ensure correct structure and input.
- Added functionality to load and execute custom browser flows, enhancing flexibility for complex site-specific automation.
- Updated documentation to include details on using custom browser flows.