### PR TITLE
feat: add transform v2 handler runtime

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,55 @@
+# Elephant CLI
+
+This context describes the county data preparation and transformation language used by the Elephant CLI. It exists so workflow, package, and data-group terms stay consistent across commands, docs, and tests.
+
+## Language
+
+**Seed Record**:
+The canonical request metadata for one parcel lookup, represented by `address.json` and `parcel.json`.
+_Avoid_: Legacy seed file, property seed when referring to the v2 structure
+
+**Capture Manifest**:
+The `captures.json` file produced by Browser Flow v2 that names captured source pages and their relative HTML paths.
+_Avoid_: Input manifest, HTML list
+
+**Capture**:
+A named source HTML artifact under `captures/` that a transform handler can read.
+_Avoid_: Page, response file
+
+**Transform v2 Handler Package**:
+A ZIP package with a root `handler.js` entrypoint that transforms prepared captures into Elephant data-group records.
+_Avoid_: Scripts ZIP, generated scripts bundle
+
+**Entity Output**:
+A schema-targeted JSON record written by a transform handler through `writeJson()`.
+_Avoid_: Data file when the distinction from relationships matters
+
+**Relationship Output**:
+A JSON file written by a transform handler through `writeRelationship()` that links two entity outputs.
+_Avoid_: Edge file, link file
+
+**Relationship Key**:
+The data-group relationship property name, such as `property_has_address`, used to place relationship outputs in a data-group root.
+_Avoid_: Relationship schema name when referring to `*_has_*` keys
+
+**Data-Group Root**:
+The CID-named JSON file with `label` and `relationships` that indexes relationship outputs for one data group.
+_Avoid_: Manifest, bundle root
+
+## Relationships
+
+- A **Seed Record** can produce one **Capture Manifest** through Browser Flow v2.
+- A **Capture Manifest** lists one or more **Captures**.
+- A **Transform v2 Handler Package** reads **Captures** and writes **Entity Outputs** and **Relationship Outputs**.
+- A **Relationship Output** links exactly two **Entity Outputs**.
+- A **Data-Group Root** indexes **Relationship Outputs** by **Relationship Key**.
+
+## Example dialogue
+
+> **Dev:** "Can the v2 transform package read both the details page and the tax page?"
+> **Domain expert:** "Yes. Browser Flow v2 records both as **Captures** in the **Capture Manifest**, and the **Transform v2 Handler Package** calls `readCapture(name)` for each one it needs."
+
+## Flagged ambiguities
+
+- "scripts ZIP" now means the v1 five-script transform bundle only; the v2 package is a **Transform v2 Handler Package**.
+- "relationship name" was split into **Relationship Key** for data-group properties and output filename stem for the physical JSON file.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This guide walks Elephant Network oracles through the complete workflow of trans
 - [Fetch Current Source Content](#fetch-current-source-content)
 - [Browser Flow Templates](#browser-flow-templates)
 - [Browser Flow v2 Handler Packages](#browser-flow-v2-handler-packages)
+- [Transform v2 Handler Packages](#transform-v2-handler-packages)
 - [Generate Transformation Scripts](#generate-transformation-scripts)
 - [Produce the County Dataset](#produce-the-county-dataset)
 - [Hash the County Dataset](#hash-the-county-dataset)
@@ -455,6 +456,25 @@ export async function handler({ input, page, saveHtml, saveSourceUrl }) {
 The output includes `captures.json` and `captures/<name>.html` files. See
 [Browser Flow v2 Handler Packages](./docs/browser-flow-v2.md) for the complete
 package contract, handler API, output manifest, and troubleshooting guide.
+
+## Transform v2 Handler Packages
+
+Transform v2 consumes Browser Flow v2 prepared ZIPs (`address.json`,
+`parcel.json`, `captures.json`, and `captures/*.html`) with a packaged
+`handler.js` transform. It is separate from the v1 `--scripts-zip` runner.
+
+```bash
+elephant-cli transform \
+  --transform-version 2 \
+  --transform-zip county-transform-v2.zip \
+  --input-zip prepared-site.zip \
+  --output-zip transformed-data.zip
+```
+
+Use transform v2 when one transform entrypoint should read one or more named
+captures and write entity and relationship JSON through the helper API. See
+[Transform v2 Handler Packages](./docs/TRANSFORM-V2.md) for the full package
+contract, context API, metadata rules, and examples.
 
 ### Multi-Request Flows
 

--- a/docs/TRANSFORM-V2.md
+++ b/docs/TRANSFORM-V2.md
@@ -1,0 +1,250 @@
+# Transform v2 Handler Packages
+
+Transform v2 consumes Browser Flow v2 prepared ZIPs and runs a packaged JavaScript handler to produce Elephant data-group JSON. It is separate from the v1 five-script `--scripts-zip` runner.
+
+## Table of Contents
+
+- [Purpose](#purpose)
+- [Command](#command)
+- [Input ZIP](#input-zip)
+- [Handler Package](#handler-package)
+- [Handler Context](#handler-context)
+- [Outputs](#outputs)
+- [Relationships And Data-Group Roots](#relationships-and-data-group-roots)
+- [Metadata Rules](#metadata-rules)
+- [Example Handler](#example-handler)
+- [Troubleshooting](#troubleshooting)
+
+## Purpose
+
+Use transform v2 when `prepare --browser-flow-version 2` produced a capture manifest and one or more named HTML captures. A v2 handler reads those captures and writes entity and relationship JSON through constrained helper functions.
+
+Transform v2 does not replace generated v1 scripts yet. `generate-transform` still emits the current five-script bundle for use with `--scripts-zip`.
+
+## Command
+
+```bash
+elephant-cli transform \
+  --transform-version 2 \
+  --transform-zip county-transform-v2.zip \
+  --input-zip prepared-site.zip \
+  --output-zip transformed-data.zip
+```
+
+**Required inputs**
+
+- `--transform-version 2`
+- `--transform-zip <path>` pointing to a v2 handler package
+- `--input-zip <path>` pointing to a Browser Flow v2 prepared ZIP
+
+**Outputs**
+
+- `transformed-data.zip`, or the path passed with `--output-zip`
+- Files inside the ZIP are written under `data/`
+
+**Options**
+
+| Option | Purpose | Default |
+| --- | --- | --- |
+| `--transform-version <version>` | Selects the transform runtime. Must be `2` for handler packages. | None |
+| `--transform-zip <path>` | ZIP containing root-level `handler.js`. | Required for v2 |
+| `--input-zip <path>` | Browser Flow v2 prepared ZIP. | Required |
+| `--output-zip <path>` | Destination transformed bundle. | `transformed-data.zip` |
+| `--data-group <label>` | Data-group label used for the CID-named root file. | `County` |
+
+Do not pass `--scripts-zip` with transform v2. `--scripts-zip` is reserved for the v1 five-script runner.
+
+## Input ZIP
+
+Transform v2 requires the Browser Flow v2 prepared structure:
+
+```text
+prepared-site.zip
+├── address.json
+├── parcel.json
+├── captures.json
+└── captures/
+    ├── property-detail.html
+    └── tax-detail.html
+```
+
+`parcel.json` must include `source_http_request` and `request_identifier`. `captures.json` must list the named captures that the handler reads.
+
+There is no root-level `input.html` fallback in transform v2. Use v1 transform scripts for legacy prepared ZIPs.
+
+## Handler Package
+
+A transform v2 package is a ZIP with a root ES module named `handler.js`:
+
+```text
+county-transform-v2.zip
+└── handler.js
+```
+
+`handler.js` must export `handler(context)`:
+
+```js
+export async function handler(context) {
+  const html = await context.readCapture('property-detail');
+  await context.writeJson('property', {
+    parcel_identifier: context.input.parcel.parcel_identifier,
+    raw_html_length: html.length,
+  });
+}
+```
+
+The handler may import local helper modules bundled in the same ZIP.
+
+### Package Config
+
+`handler.js` may export `config`:
+
+```js
+export const config = {
+  timeoutMs: 120000,
+};
+```
+
+`timeoutMs` defaults to `120000`. It must be between `1000` and `600000`.
+
+## Handler Context
+
+The handler receives a context with input data and helper functions:
+
+```ts
+interface TransformV2Context {
+  input: {
+    request_identifier: string;
+    source_http_request: Request;
+    address: Record<string, unknown>;
+    parcel: Record<string, unknown>;
+    captures: BrowserFlowV2Manifest;
+    readCapture(name: string): Promise<string>;
+  };
+  readCapture(name: string): Promise<string>;
+  writeJson(name: string, value: Record<string, unknown>): Promise<void>;
+  writeRelationship(options: {
+    type: string;
+    name: string;
+    from: string;
+    to: string;
+  }): Promise<void>;
+  logger: Logger;
+}
+```
+
+`readCapture(name)` reads one capture by its `captures.json` name. Handlers can read multiple captures.
+
+`writeJson(name, value)` writes one entity output. `name` is a snake_case filename stem; the CLI writes `data/<name>.json`.
+
+`writeRelationship(options)` writes one relationship output. `type` is the data-group relationship key, such as `property_has_address`. `name` is a snake_case filename stem. `from` and `to` must reference entity output stems already written with `writeJson()`.
+
+## Outputs
+
+Transform v2 writes a ZIP with files under `data/`:
+
+```text
+transformed-data.zip
+└── data/
+    ├── property.json
+    ├── address.json
+    ├── relationship_property_address.json
+    └── <data-group-schema-cid>.json
+```
+
+The CLI does not automatically copy `address.json` or `parcel.json` into output. If a handler wants seed records in the transformed bundle, it must write them explicitly:
+
+```js
+await writeJson('address', input.address);
+await writeJson('parcel', input.parcel);
+```
+
+## Relationships And Data-Group Roots
+
+Handlers write relationships with explicit data-group relationship keys:
+
+```js
+await writeRelationship({
+  type: 'property_has_address',
+  name: 'relationship_property_address',
+  from: 'property',
+  to: 'address',
+});
+```
+
+The CLI writes the relationship file:
+
+```json
+{
+  "from": { "/": "./property.json" },
+  "to": { "/": "./address.json" }
+}
+```
+
+Then it creates the CID-named data-group root. Relationship cardinality is derived from the selected data-group schema, so singleton relationship keys become a single IPLD reference and array relationship keys become arrays.
+
+## Metadata Rules
+
+For entity outputs written through `writeJson()`:
+
+- `request_identifier` is always set to the input request identifier from `parcel.json`.
+- `source_http_request` is copied from `parcel.json` when the handler did not provide one.
+- Handler-provided `source_http_request` is preserved so different captures can point to different source requests.
+
+Relationship outputs do not receive `source_http_request` or `request_identifier`.
+
+## Example Handler
+
+```js
+export const config = {
+  timeoutMs: 120000,
+};
+
+export async function handler({ input, readCapture, writeJson, writeRelationship }) {
+  const html = await readCapture('property-detail');
+
+  await writeJson('property', {
+    parcel_identifier: input.parcel.parcel_identifier,
+    page_has_property_heading: html.includes('Property Detail'),
+  });
+
+  await writeJson('address', input.address);
+
+  await writeRelationship({
+    type: 'property_has_address',
+    name: 'relationship_property_address',
+    from: 'property',
+    to: 'address',
+  });
+}
+```
+
+Package it:
+
+```bash
+zip county-transform-v2.zip handler.js
+```
+
+Run it:
+
+```bash
+elephant-cli transform \
+  --transform-version 2 \
+  --transform-zip county-transform-v2.zip \
+  --input-zip prepared-site.zip \
+  --output-zip transformed-data.zip
+```
+
+## Troubleshooting
+
+`--transform-zip requires --transform-version 2` means the handler package flag was passed without selecting the v2 runtime.
+
+`--scripts-zip cannot be used with transform v2` means the v1 and v2 package contracts were mixed.
+
+`captures.json is required for transform v2` means the input ZIP was not produced by Browser Flow v2 or the manifest was removed.
+
+`Unknown capture: <name>` means the handler requested a capture name that is not listed in `captures.json`.
+
+`Invalid output name` means a helper name was not a snake_case filename stem.
+
+`Relationship type "<type>" is not valid for <data-group>` means the selected data-group schema does not define that relationship key.

--- a/docs/adr/0001-transform-v2-handler-packages.md
+++ b/docs/adr/0001-transform-v2-handler-packages.md
@@ -1,0 +1,11 @@
+# Transform v2 uses handler packages
+
+Transform v2 uses a distinct handler ZIP with a root `handler.js` entrypoint instead of overloading the v1 five-script `--scripts-zip` bundle. We chose this because Browser Flow v2 now produces a capture manifest with named captures, and a single handler context with constrained helpers is a clearer contract for consuming those captures than preserving the old fixed script sequence. The v1 scripts bundle remains unchanged so existing generated transforms keep working while v2 establishes a separate package shape.
+
+## Considered Options
+
+- Reuse `--scripts-zip` and infer v1 versus v2 from `--transform-version`.
+- Add `--transform-zip` as a distinct v2 package flag.
+- Accept `--scripts-zip` as a temporary v2 alias.
+
+We chose a distinct `--transform-zip` with explicit `--transform-version 2` so callers cannot accidentally mix the v1 five-script runner with the v2 handler runtime.

--- a/src/commands/transform/index.ts
+++ b/src/commands/transform/index.ts
@@ -16,6 +16,7 @@ import { generateHTMLFiles } from '../../utils/fact-sheet.js';
 import { SchemaManifestService } from '../../services/schema-manifest.service.js';
 import { FactSheetRelationshipService } from '../../services/fact-sheet-relationship.service.js';
 import { SchemaCacheService } from '../../services/schema-cache.service.js';
+import { executeTransformV2 } from '../../lib/transform-v2.js';
 import {
   parseMultiValueQueryString,
   SourceHttpRequest,
@@ -28,6 +29,8 @@ export interface TransformCommandOptions {
   outputZip?: string;
   inputZip?: string;
   scriptsZip?: string;
+  transformVersion?: 2 | '2';
+  transformZip?: string;
   legacyMode?: boolean;
   silent?: boolean;
   cwd?: string;
@@ -94,6 +97,8 @@ export function registerTransformCommand(program: Command) {
       '--scripts-zip <path>',
       'Run transformation using generated scripts ZIP'
     )
+    .option('--transform-version <version>', 'Transform runtime version to use')
+    .option('--transform-zip <path>', 'Path to transform v2 handler ZIP file')
     .option(
       '--input-zip <path>',
       'Input ZIP for scripts mode (must include address.json or unnormalized_address.json, parcel.json or property_seed.json, and an HTML/JSON file)'
@@ -113,6 +118,34 @@ export async function handleTransform(options: TransformCommandOptions) {
   if (!options.silent) {
     console.log(chalk.bold.blue('🐘 Elephant Network CLI - Transform'));
     console.log();
+  }
+
+  const usesTransformV2 =
+    options.transformVersion === 2 || options.transformVersion === '2';
+  if (options.transformZip && !usesTransformV2) {
+    throw new Error('--transform-zip requires --transform-version 2');
+  }
+  if (usesTransformV2 && !options.transformZip) {
+    throw new Error('--transform-zip is required for transform v2');
+  }
+  if (usesTransformV2 && options.scriptsZip) {
+    throw new Error('--scripts-zip cannot be used with transform v2');
+  }
+  if (usesTransformV2 && !options.inputZip) {
+    throw new Error('In transform v2, --input-zip is required');
+  }
+  if (usesTransformV2) {
+    const workingDir = options.cwd || process.cwd();
+    await executeTransformV2({
+      inputZip: path.resolve(workingDir, options.inputZip!),
+      outputZip: path.resolve(
+        workingDir,
+        options.outputZip || 'transformed-data.zip'
+      ),
+      transformZip: path.resolve(workingDir, options.transformZip!),
+      dataGroup: options.dataGroup,
+    });
+    return;
   }
 
   if (options.legacyMode) {

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -44,6 +44,8 @@ export interface GenerateTransformResult {
 export interface TransformOptions {
   outputZip?: string;
   scriptsZip?: string;
+  transformVersion?: 2 | '2';
+  transformZip?: string;
   inputZip: string;
   legacyMode?: boolean;
   cwd?: string;
@@ -163,6 +165,8 @@ export async function transform(
   const transformOptions: TransformCommandOptions = {
     outputZip,
     scriptsZip: options.scriptsZip,
+    transformVersion: options.transformVersion,
+    transformZip: options.transformZip,
     inputZip: options.inputZip,
     legacyMode: options.legacyMode || false,
     silent: true, // Enable silent mode for library usage
@@ -188,6 +192,8 @@ export async function transform(
     const stderrTail = tail(split(stderrMarker));
     const stdoutTail = tail(split(stdoutMarker));
     const summary = msg.split('\n---')[0]?.trim() || msg;
+    const isTransformV2 =
+      options.transformVersion === 2 || options.transformVersion === '2';
     const failure =
       stderrTail || stdoutTail
         ? {
@@ -195,7 +201,11 @@ export async function transform(
             stdout: stdoutTail,
             stderr: stderrTail,
           }
-        : undefined;
+        : isTransformV2
+          ? {
+              message: summary,
+            }
+          : undefined;
 
     return {
       success: false,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -38,6 +38,12 @@ export type {
   BrowserFlowV2Manifest,
   SaveHtmlOptions,
 } from './browser-flow-v2.js';
+export type {
+  TransformV2Config,
+  TransformV2Context,
+  TransformV2Input,
+  WriteRelationshipOptions,
+} from './transform-v2.js';
 
 // Export gas price types
 export type { GasPriceInfo } from '../services/gas-price.service.js';

--- a/src/lib/transform-v2.ts
+++ b/src/lib/transform-v2.ts
@@ -97,6 +97,14 @@ async function readJsonFile<T>(file: string): Promise<T> {
   return JSON.parse(await fs.readFile(file, 'utf-8')) as T;
 }
 
+function parseCaptures(content: string): BrowserFlowV2Manifest {
+  try {
+    return JSON.parse(content) as BrowserFlowV2Manifest;
+  } catch {
+    throw new Error('captures.json is invalid JSON');
+  }
+}
+
 function getTimeoutMs(config: TransformV2Config | undefined) {
   const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   if (
@@ -205,12 +213,12 @@ export async function executeTransformV2(options: TransformV2Options) {
     const dir = await extractZipToTemp(options.inputZip, root, 'input');
     const outputDir = path.join(root, 'data');
     const capturesPath = path.join(dir, 'captures.json');
-    const captures = await fs
+    const capturesContent = await fs
       .readFile(capturesPath, 'utf-8')
-      .then((content) => JSON.parse(content) as BrowserFlowV2Manifest)
       .catch(() => {
         throw new Error('captures.json is required for transform v2');
       });
+    const captures = parseCaptures(capturesContent);
     const address = await readJsonFile<Record<string, unknown>>(
       path.join(dir, 'address.json')
     );

--- a/src/lib/transform-v2.ts
+++ b/src/lib/transform-v2.ts
@@ -1,0 +1,337 @@
+import path from 'path';
+import AdmZip from 'adm-zip';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { pathToFileURL } from 'url';
+import { extractZipToTemp } from '../utils/zip.js';
+import { BrowserFlowV2Manifest } from './browser-flow-v2.js';
+import { Request } from './types.js';
+import { logger } from '../utils/logger.js';
+import { SchemaManifestService } from '../services/schema-manifest.service.js';
+import {
+  JSONSchema,
+  SchemaCacheService,
+} from '../services/schema-cache.service.js';
+
+interface TransformV2Options {
+  inputZip: string;
+  transformZip: string;
+  outputZip: string;
+  dataGroup?: string;
+}
+
+export interface TransformV2Input {
+  request_identifier: string;
+  source_http_request: Request;
+  address: Record<string, unknown>;
+  parcel: Record<string, unknown>;
+  captures: BrowserFlowV2Manifest;
+  readCapture(name: string): Promise<string>;
+}
+
+export interface WriteRelationshipOptions {
+  type: string;
+  name: string;
+  from: string;
+  to: string;
+}
+
+export interface TransformV2Context {
+  input: TransformV2Input;
+  readCapture(name: string): Promise<string>;
+  writeJson(name: string, value: Record<string, unknown>): Promise<void>;
+  writeRelationship(options: WriteRelationshipOptions): Promise<void>;
+  logger: typeof logger;
+}
+
+export interface TransformV2Config {
+  timeoutMs?: number;
+}
+
+interface TransformV2Module {
+  handler: (context: TransformV2Context) => Promise<void>;
+  config?: TransformV2Config;
+}
+
+interface RelationshipRef {
+  file: string;
+  ref: { '/': string };
+}
+
+const OUTPUT_NAME_PATTERN = /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/;
+const DEFAULT_TIMEOUT_MS = 120000;
+const MIN_TIMEOUT_MS = 1000;
+const MAX_TIMEOUT_MS = 600000;
+
+async function loadHandler(transformZip: string, root: string) {
+  const dir = path.join(root, 'handler');
+  await fs.mkdir(dir, { recursive: true });
+  new AdmZip(transformZip).extractAllTo(dir, true);
+
+  const handlerPath = path.join(dir, 'handler.js');
+  await fs.access(handlerPath);
+
+  const mod = (await import(
+    `${pathToFileURL(handlerPath).href}?t=${Date.now()}`
+  )) as Partial<TransformV2Module>;
+
+  if (typeof mod.handler !== 'function') {
+    throw new Error('Transform v2 package must export a handler function');
+  }
+
+  return {
+    handler: mod.handler,
+    config: mod.config,
+  };
+}
+
+function validateOutputName(name: string) {
+  if (!OUTPUT_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid output name "${name}". Output names must be snake_case stems.`
+    );
+  }
+}
+
+async function readJsonFile<T>(file: string): Promise<T> {
+  return JSON.parse(await fs.readFile(file, 'utf-8')) as T;
+}
+
+function getTimeoutMs(config: TransformV2Config | undefined) {
+  const timeoutMs = config?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  if (
+    !Number.isInteger(timeoutMs) ||
+    timeoutMs < MIN_TIMEOUT_MS ||
+    timeoutMs > MAX_TIMEOUT_MS
+  ) {
+    throw new Error(
+      `Transform v2 timeoutMs must be between ${MIN_TIMEOUT_MS}ms and ${MAX_TIMEOUT_MS}ms`
+    );
+  }
+  return timeoutMs;
+}
+
+async function withTimeout(action: Promise<void>, timeoutMs: number) {
+  let timeout: NodeJS.Timeout | undefined;
+  const timer = new Promise<never>((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(`Transform v2 timed out after ${timeoutMs}ms`)),
+      timeoutMs
+    );
+  });
+
+  try {
+    await Promise.race([action, timer]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function schemaTypeIncludes(schema: JSONSchema | undefined, type: string) {
+  if (!schema) {
+    return false;
+  }
+  if (schema.type === type) {
+    return true;
+  }
+  if (Array.isArray(schema.type)) {
+    return schema.type.includes(type);
+  }
+  return false;
+}
+
+function getRelationshipSchema(schema: JSONSchema, type: string) {
+  const relationships = schema.properties?.relationships;
+  return relationships?.properties?.[type];
+}
+
+async function createDataGroupRoot(
+  outputDir: string,
+  dataGroup: string,
+  relationships: Map<string, RelationshipRef[]>
+) {
+  if (relationships.size === 0) {
+    return;
+  }
+
+  const manifest = new SchemaManifestService();
+  await manifest.loadSchemaManifest();
+  const cid = manifest.getDataGroupCidByLabel(dataGroup);
+  if (!cid) {
+    throw new Error(`Schema not found for data group type: ${dataGroup}`);
+  }
+
+  const cache = new SchemaCacheService();
+  const schema = await cache.get(cid);
+  const root: Record<string, unknown> = {};
+
+  for (const [type, refs] of relationships) {
+    const relSchema = getRelationshipSchema(schema, type);
+    if (!relSchema) {
+      throw new Error(
+        `Relationship type "${type}" is not valid for ${dataGroup}`
+      );
+    }
+    if (schemaTypeIncludes(relSchema, 'array')) {
+      root[type] = refs.map((ref) => ref.ref);
+      continue;
+    }
+    if (refs.length > 1) {
+      throw new Error(
+        `Relationship type "${type}" only allows one relationship`
+      );
+    }
+    root[type] = refs[0].ref;
+  }
+
+  await fs.writeFile(
+    path.join(outputDir, `${cid}.json`),
+    JSON.stringify(
+      {
+        label: dataGroup,
+        relationships: root,
+      },
+      null,
+      2
+    ),
+    'utf-8'
+  );
+}
+
+export async function executeTransformV2(options: TransformV2Options) {
+  const root = await fs.mkdtemp(path.join(tmpdir(), 'elephant-transform-v2-'));
+
+  try {
+    const dir = await extractZipToTemp(options.inputZip, root, 'input');
+    const outputDir = path.join(root, 'data');
+    const capturesPath = path.join(dir, 'captures.json');
+    const captures = await fs
+      .readFile(capturesPath, 'utf-8')
+      .then((content) => JSON.parse(content) as BrowserFlowV2Manifest)
+      .catch(() => {
+        throw new Error('captures.json is required for transform v2');
+      });
+    const address = await readJsonFile<Record<string, unknown>>(
+      path.join(dir, 'address.json')
+    );
+    const parcel = await readJsonFile<Record<string, unknown>>(
+      path.join(dir, 'parcel.json')
+    );
+    const request = parcel.source_http_request as Request | undefined;
+    const id = parcel.request_identifier as string | undefined;
+
+    if (!request) {
+      throw new Error('parcel.json missing source_http_request');
+    }
+    if (!id) {
+      throw new Error('parcel.json missing request_identifier');
+    }
+
+    const mod = await loadHandler(options.transformZip, root);
+    const timeoutMs = getTimeoutMs(mod.config);
+    const outputs = new Set<string>();
+    const relationships = new Map<string, RelationshipRef[]>();
+
+    await fs.mkdir(outputDir, { recursive: true });
+
+    const readCapture = async (name: string) => {
+      const capture = captures.captures.find((item) => item.name === name);
+      if (!capture) {
+        throw new Error(`Unknown capture: ${name}`);
+      }
+      return await fs.readFile(path.join(dir, capture.path), 'utf-8');
+    };
+
+    const writeJson = async (name: string, value: Record<string, unknown>) => {
+      validateOutputName(name);
+      if (outputs.has(name)) {
+        throw new Error(`Duplicate output name: ${name}`);
+      }
+
+      outputs.add(name);
+      await fs.writeFile(
+        path.join(outputDir, `${name}.json`),
+        JSON.stringify(
+          {
+            ...value,
+            source_http_request: value.source_http_request ?? request,
+            request_identifier: id,
+          },
+          null,
+          2
+        ),
+        'utf-8'
+      );
+    };
+
+    const writeRelationship = async (options: WriteRelationshipOptions) => {
+      validateOutputName(options.name);
+      if (outputs.has(options.name)) {
+        throw new Error(`Duplicate output name: ${options.name}`);
+      }
+      if (!outputs.has(options.from)) {
+        throw new Error(`Unknown relationship source: ${options.from}`);
+      }
+      if (!outputs.has(options.to)) {
+        throw new Error(`Unknown relationship target: ${options.to}`);
+      }
+
+      outputs.add(options.name);
+      const file = `${options.name}.json`;
+      await fs.writeFile(
+        path.join(outputDir, file),
+        JSON.stringify(
+          {
+            from: { '/': `./${options.from}.json` },
+            to: { '/': `./${options.to}.json` },
+          },
+          null,
+          2
+        ),
+        'utf-8'
+      );
+
+      const refs = relationships.get(options.type) ?? [];
+      refs.push({
+        file,
+        ref: { '/': `./${file}` },
+      });
+      relationships.set(options.type, refs);
+    };
+
+    await withTimeout(
+      mod.handler({
+        input: {
+          request_identifier: id,
+          source_http_request: request,
+          address,
+          parcel,
+          captures,
+          readCapture,
+        },
+        readCapture,
+        writeJson,
+        writeRelationship,
+        logger,
+      }),
+      timeoutMs
+    );
+
+    await createDataGroupRoot(
+      outputDir,
+      options.dataGroup ?? 'County',
+      relationships
+    );
+
+    const zip = new AdmZip();
+    const entries = await fs.readdir(outputDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        zip.addLocalFile(path.join(outputDir, entry.name), 'data');
+      }
+    }
+    zip.writeZip(options.outputZip);
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}

--- a/src/lib/transform-v2.ts
+++ b/src/lib/transform-v2.ts
@@ -230,6 +230,7 @@ export async function executeTransformV2(options: TransformV2Options) {
     const mod = await loadHandler(options.transformZip, root);
     const timeoutMs = getTimeoutMs(mod.config);
     const outputs = new Set<string>();
+    const entities = new Set<string>();
     const relationships = new Map<string, RelationshipRef[]>();
 
     await fs.mkdir(outputDir, { recursive: true });
@@ -239,7 +240,13 @@ export async function executeTransformV2(options: TransformV2Options) {
       if (!capture) {
         throw new Error(`Unknown capture: ${name}`);
       }
-      return await fs.readFile(path.join(dir, capture.path), 'utf-8');
+      const inputRoot = path.resolve(dir);
+      const resolved = path.resolve(inputRoot, capture.path);
+      const relative = path.relative(inputRoot, resolved);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new Error(`Invalid capture path: ${capture.path}`);
+      }
+      return await fs.readFile(resolved, 'utf-8');
     };
 
     const writeJson = async (name: string, value: Record<string, unknown>) => {
@@ -249,6 +256,7 @@ export async function executeTransformV2(options: TransformV2Options) {
       }
 
       outputs.add(name);
+      entities.add(name);
       await fs.writeFile(
         path.join(outputDir, `${name}.json`),
         JSON.stringify(
@@ -269,10 +277,10 @@ export async function executeTransformV2(options: TransformV2Options) {
       if (outputs.has(options.name)) {
         throw new Error(`Duplicate output name: ${options.name}`);
       }
-      if (!outputs.has(options.from)) {
+      if (!entities.has(options.from)) {
         throw new Error(`Unknown relationship source: ${options.from}`);
       }
-      if (!outputs.has(options.to)) {
+      if (!entities.has(options.to)) {
         throw new Error(`Unknown relationship target: ${options.to}`);
       }
 

--- a/tests/unit/commands/transform.test.ts
+++ b/tests/unit/commands/transform.test.ts
@@ -107,6 +107,45 @@ describe('transform command', () => {
 
   describe('handleTransform', () => {
     const options = { legacyMode: true };
+    it('rejects transform v2 package without explicit version flag', async () => {
+      await expect(
+        handleTransform({
+          transformZip: 'transform-v2.zip',
+          silent: true,
+        })
+      ).rejects.toThrow('--transform-zip requires --transform-version 2');
+    });
+
+    it('requires a transform v2 package when version 2 is selected', async () => {
+      await expect(
+        handleTransform({
+          transformVersion: 2,
+          silent: true,
+        })
+      ).rejects.toThrow('--transform-zip is required for transform v2');
+    });
+
+    it('rejects scripts zip when transform v2 is selected', async () => {
+      await expect(
+        handleTransform({
+          transformVersion: 2,
+          transformZip: 'transform-v2.zip',
+          scriptsZip: 'generated-scripts.zip',
+          silent: true,
+        })
+      ).rejects.toThrow('--scripts-zip cannot be used with transform v2');
+    });
+
+    it('requires an input zip when transform v2 is selected', async () => {
+      await expect(
+        handleTransform({
+          transformVersion: 2,
+          transformZip: 'transform-v2.zip',
+          silent: true,
+        })
+      ).rejects.toThrow('In transform v2, --input-zip is required');
+    });
+
     it('should successfully transform data with default output zip', async () => {
       const options = { legacyMode: true };
 

--- a/tests/unit/lib/commands.test.ts
+++ b/tests/unit/lib/commands.test.ts
@@ -40,6 +40,29 @@ describe('Library Commands', () => {
       expect(options.outputZip).toBe('test-output.zip');
     });
 
+    it('should pass transform v2 options to CLI implementation', async () => {
+      const { handleTransform } = await import(
+        '../../../src/commands/transform/index.js'
+      );
+
+      await transform({
+        inputZip: 'test-input.zip',
+        transformVersion: 2,
+        transformZip: 'transform-v2.zip',
+        outputZip: 'test-output.zip',
+      });
+
+      expect(handleTransform).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputZip: 'test-input.zip',
+          transformVersion: 2,
+          transformZip: 'transform-v2.zip',
+          outputZip: expect.stringContaining('test-output.zip'),
+          silent: true,
+        })
+      );
+    });
+
     it('should pass dataGroup option to CLI implementation', async () => {
       const { handleTransform } = await import(
         '../../../src/commands/transform/index.js'

--- a/tests/unit/lib/transform-v2.test.ts
+++ b/tests/unit/lib/transform-v2.test.ts
@@ -1,0 +1,421 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import AdmZip from 'adm-zip';
+import { handleTransform } from '../../../src/commands/transform/index.js';
+import { transform } from '../../../src/lib/commands.js';
+
+vi.mock('../../../src/services/schema-manifest.service.js', () => ({
+  SchemaManifestService: vi.fn().mockImplementation(() => ({
+    loadSchemaManifest: vi.fn().mockResolvedValue({
+      County: {
+        ipfsCid: 'county-schema-cid',
+        type: 'dataGroup',
+      },
+    }),
+    getDataGroupCidByLabel: vi.fn((label: string) =>
+      label === 'County' ? 'county-schema-cid' : null
+    ),
+  })),
+}));
+
+vi.mock('../../../src/services/schema-cache.service.js', () => ({
+  SchemaCacheService: vi.fn().mockImplementation(() => ({
+    get: vi.fn().mockResolvedValue({
+      type: 'object',
+      properties: {
+        relationships: {
+          type: 'object',
+          properties: {
+            property_has_address: {
+              type: ['string', 'null'],
+            },
+          },
+        },
+      },
+    }),
+  })),
+}));
+
+describe('transform v2', () => {
+  let dir: string;
+  let inputZip: string;
+  let transformZip: string;
+  let outputZip: string;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'transform-v2-'));
+    inputZip = path.join(dir, 'input.zip');
+    transformZip = path.join(dir, 'transform.zip');
+    outputZip = path.join(dir, 'output.zip');
+  });
+
+  afterEach(async () => {
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('requires a prepare v2 captures manifest', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from('export async function handler() {}')
+    );
+    handler.writeZip(transformZip);
+
+    await expect(
+      handleTransform({
+        inputZip,
+        outputZip,
+        transformVersion: 2,
+        transformZip,
+        silent: true,
+      })
+    ).rejects.toThrow('captures.json is required for transform v2');
+  });
+
+  it('returns transform v2 failures through scriptFailure in the library API', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from('export async function handler() {}')
+    );
+    handler.writeZip(transformZip);
+
+    const result = await transform({
+      inputZip,
+      outputZip,
+      transformVersion: 2,
+      transformZip,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('captures.json is required for transform v2');
+    expect(result.scriptFailure).toEqual({
+      message: 'captures.json is required for transform v2',
+    });
+  });
+
+  it('runs a handler package and writes entity JSON with request metadata', async () => {
+    const sourceHttpRequest = {
+      method: 'GET',
+      url: 'https://county.example/search',
+      multiValueQueryString: {
+        id: ['parcel-123'],
+      },
+    };
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: sourceHttpRequest,
+        })
+      )
+    );
+    input.addFile(
+      'captures.json',
+      Buffer.from(
+        JSON.stringify({
+          version: 2,
+          request_identifier: 'parcel-123',
+          sourceUrl: 'https://county.example/details?id=parcel-123',
+          captures: [
+            {
+              name: 'property-detail',
+              path: 'captures/property-detail.html',
+              type: 'html',
+            },
+          ],
+        })
+      )
+    );
+    input.addFile(
+      'captures/property-detail.html',
+      Buffer.from('<html><body><h1>Property Detail</h1></body></html>')
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from(`
+export async function handler({ readCapture, writeJson }) {
+  const html = await readCapture('property-detail');
+  await writeJson('property', {
+    parcel_identifier: html.includes('Property Detail') ? 'parcel-123' : 'missing'
+  });
+}
+`)
+    );
+    handler.writeZip(transformZip);
+
+    await handleTransform({
+      inputZip,
+      outputZip,
+      transformVersion: 2,
+      transformZip,
+      silent: true,
+    });
+
+    const output = new AdmZip(outputZip);
+    const entries = output
+      .getEntries()
+      .map((entry) => entry.entryName)
+      .sort();
+
+    expect(entries).toEqual(['data/property.json']);
+    expect(JSON.parse(output.readAsText('data/property.json') || '{}')).toEqual(
+      {
+        parcel_identifier: 'parcel-123',
+        request_identifier: 'parcel-123',
+        source_http_request: sourceHttpRequest,
+      }
+    );
+  });
+
+  it('writes relationships and creates a schema-aware data-group root', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.addFile(
+      'captures.json',
+      Buffer.from(
+        JSON.stringify({
+          version: 2,
+          request_identifier: 'parcel-123',
+          sourceUrl: 'https://county.example/details?id=parcel-123',
+          captures: [
+            {
+              name: 'property-detail',
+              path: 'captures/property-detail.html',
+              type: 'html',
+            },
+          ],
+        })
+      )
+    );
+    input.addFile(
+      'captures/property-detail.html',
+      Buffer.from('<html><body><h1>Property Detail</h1></body></html>')
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from(`
+export async function handler({ input, writeJson, writeRelationship }) {
+  await writeJson('property', { parcel_identifier: input.parcel.parcel_identifier });
+  await writeJson('address', input.address);
+  await writeRelationship({
+    type: 'property_has_address',
+    name: 'relationship_property_address',
+    from: 'property',
+    to: 'address'
+  });
+}
+`)
+    );
+    handler.writeZip(transformZip);
+
+    await handleTransform({
+      inputZip,
+      outputZip,
+      transformVersion: 2,
+      transformZip,
+      silent: true,
+    });
+
+    const output = new AdmZip(outputZip);
+    const entries = output
+      .getEntries()
+      .map((entry) => entry.entryName)
+      .sort();
+
+    expect(entries).toEqual([
+      'data/address.json',
+      'data/county-schema-cid.json',
+      'data/property.json',
+      'data/relationship_property_address.json',
+    ]);
+    expect(
+      JSON.parse(
+        output.readAsText('data/relationship_property_address.json') || '{}'
+      )
+    ).toEqual({
+      from: { '/': './property.json' },
+      to: { '/': './address.json' },
+    });
+    expect(
+      JSON.parse(output.readAsText('data/county-schema-cid.json') || '{}')
+    ).toEqual({
+      label: 'County',
+      relationships: {
+        property_has_address: { '/': './relationship_property_address.json' },
+      },
+    });
+  });
+
+  it('validates timeout configuration exported by the handler package', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.addFile(
+      'captures.json',
+      Buffer.from(
+        JSON.stringify({
+          version: 2,
+          request_identifier: 'parcel-123',
+          sourceUrl: 'https://county.example/details?id=parcel-123',
+          captures: [
+            {
+              name: 'property-detail',
+              path: 'captures/property-detail.html',
+              type: 'html',
+            },
+          ],
+        })
+      )
+    );
+    input.addFile(
+      'captures/property-detail.html',
+      Buffer.from('<html><body><h1>Property Detail</h1></body></html>')
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from(`
+export const config = { timeoutMs: 999 };
+
+export async function handler() {
+}
+`)
+    );
+    handler.writeZip(transformZip);
+
+    await expect(
+      handleTransform({
+        inputZip,
+        outputZip,
+        transformVersion: 2,
+        transformZip,
+        silent: true,
+      })
+    ).rejects.toThrow(
+      'Transform v2 timeoutMs must be between 1000ms and 600000ms'
+    );
+  });
+});

--- a/tests/unit/lib/transform-v2.test.ts
+++ b/tests/unit/lib/transform-v2.test.ts
@@ -101,6 +101,53 @@ describe('transform v2', () => {
     ).rejects.toThrow('captures.json is required for transform v2');
   });
 
+  it('reports malformed capture manifests separately from missing manifests', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.addFile('captures.json', Buffer.from('{'));
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from('export async function handler() {}')
+    );
+    handler.writeZip(transformZip);
+
+    await expect(
+      handleTransform({
+        inputZip,
+        outputZip,
+        transformVersion: 2,
+        transformZip,
+        silent: true,
+      })
+    ).rejects.toThrow('captures.json is invalid JSON');
+  });
+
   it('returns transform v2 failures through scriptFailure in the library API', async () => {
     const input = new AdmZip();
     input.addFile(

--- a/tests/unit/lib/transform-v2.test.ts
+++ b/tests/unit/lib/transform-v2.test.ts
@@ -345,6 +345,160 @@ export async function handler({ input, writeJson, writeRelationship }) {
     });
   });
 
+  it('rejects capture paths that escape the prepared input directory', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.addFile(
+      'captures.json',
+      Buffer.from(
+        JSON.stringify({
+          version: 2,
+          request_identifier: 'parcel-123',
+          sourceUrl: 'https://county.example/details?id=parcel-123',
+          captures: [
+            {
+              name: 'property-detail',
+              path: '../../../package.json',
+              type: 'html',
+            },
+          ],
+        })
+      )
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from(`
+export async function handler({ readCapture, writeJson }) {
+  const content = await readCapture('property-detail');
+  await writeJson('property', { leaked: content.length });
+}
+`)
+    );
+    handler.writeZip(transformZip);
+
+    await expect(
+      handleTransform({
+        inputZip,
+        outputZip,
+        transformVersion: 2,
+        transformZip,
+        silent: true,
+      })
+    ).rejects.toThrow('Invalid capture path: ../../../package.json');
+  });
+
+  it('rejects relationships that reference relationship outputs', async () => {
+    const input = new AdmZip();
+    input.addFile(
+      'address.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          county_name: 'Example',
+          unnormalized_address: '123 Main St',
+        })
+      )
+    );
+    input.addFile(
+      'parcel.json',
+      Buffer.from(
+        JSON.stringify({
+          request_identifier: 'parcel-123',
+          parcel_identifier: 'parcel-123',
+          source_http_request: {
+            method: 'GET',
+            url: 'https://county.example/search',
+            multiValueQueryString: {},
+          },
+        })
+      )
+    );
+    input.addFile(
+      'captures.json',
+      Buffer.from(
+        JSON.stringify({
+          version: 2,
+          request_identifier: 'parcel-123',
+          sourceUrl: 'https://county.example/details?id=parcel-123',
+          captures: [
+            {
+              name: 'property-detail',
+              path: 'captures/property-detail.html',
+              type: 'html',
+            },
+          ],
+        })
+      )
+    );
+    input.addFile(
+      'captures/property-detail.html',
+      Buffer.from('<html><body><h1>Property Detail</h1></body></html>')
+    );
+    input.writeZip(inputZip);
+
+    const handler = new AdmZip();
+    handler.addFile(
+      'handler.js',
+      Buffer.from(`
+export async function handler({ input, writeJson, writeRelationship }) {
+  await writeJson('property', { parcel_identifier: input.parcel.parcel_identifier });
+  await writeJson('address', input.address);
+  await writeRelationship({
+    type: 'property_has_address',
+    name: 'relationship_property_address',
+    from: 'property',
+    to: 'address'
+  });
+  await writeRelationship({
+    type: 'property_has_address',
+    name: 'relationship_property_address_2',
+    from: 'relationship_property_address',
+    to: 'address'
+  });
+}
+`)
+    );
+    handler.writeZip(transformZip);
+
+    await expect(
+      handleTransform({
+        inputZip,
+        outputZip,
+        transformVersion: 2,
+        transformZip,
+        silent: true,
+      })
+    ).rejects.toThrow(
+      'Unknown relationship source: relationship_property_address'
+    );
+  });
+
   it('validates timeout configuration exported by the handler package', async () => {
     const input = new AdmZip();
     input.addFile(


### PR DESCRIPTION
## Summary
- Add transform v2 handler ZIP runtime for Browser Flow v2 capture manifests.
- Add CLI/library option gating, public handler types, schema-aware relationship/data-group output, and docs.
- Preserve v1 `--scripts-zip` behavior while documenting the new v2 package contract.

## Test plan
- npm run test -- tests/unit/commands/transform.test.ts tests/unit/lib/commands.test.ts tests/unit/lib/transform-v2.test.ts
- npm run build
- npm run lint
- npm run format:check


Made with [Cursor](https://cursor.com)