### PR TITLE
fix(prepare/orange): zero-pad parcel id to 15 + retry QuickSearch on empty

### DIFF
--- a/src/lib/county-specific-prepare/orange.ts
+++ b/src/lib/county-specific-prepare/orange.ts
@@ -37,7 +37,16 @@ async function resolveParcelId(pid: string): Promise<QuickSearchResult[]> {
     }
 
     const data = await response.json();
-    if (Array.isArray(data) && data.length > 0) {
+    // Fast-fail on a structurally-unexpected (non-array) body — e.g. an error
+    // or rate-limit envelope. Only a valid-but-empty array is a retryable
+    // "not found yet"; folding non-arrays into the retry loop would mask a
+    // malformed response as a mere empty result.
+    if (!Array.isArray(data)) {
+      throw new Error(
+        `Quick search for parcel ${pid} returned unexpected format (attempt ${attempt})`
+      );
+    }
+    if (data.length > 0) {
       return data as QuickSearchResult[];
     }
 

--- a/src/lib/county-specific-prepare/orange.ts
+++ b/src/lib/county-specific-prepare/orange.ts
@@ -1,6 +1,59 @@
 import { Prepared } from '../types.js';
 import { logger } from '../../utils/logger.js';
 
+// OCPA's QuickSearch endpoint requires a 15-digit parcel id, but the county
+// seed stores mixed 14/15-digit ids (numeric CSV storage strips leading
+// zeros). Pad to 15 so 14-digit ids resolve instead of returning [].
+const OCPA_PID_LENGTH = 15;
+
+// OCPA intermittently returns an empty array/body for a valid id (measured
+// ~16% first-pass in the pilot; all recovered on retry). Retry on empty with
+// a short increasing backoff before treating the id as not found. This is
+// local to Orange so no other county's fetch behavior changes.
+const EMPTY_RETRY_ATTEMPTS = 4;
+const EMPTY_RETRY_BASE_DELAY_MS = 300;
+
+interface QuickSearchResult {
+  parcelId?: string;
+  [key: string]: unknown;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Resolve the canonical OCPA parcelId. Retries only when the response is a
+// valid HTTP 2xx with an empty array; genuine HTTP errors are thrown
+// immediately (not retried) so existing error handling is unchanged.
+async function resolveParcelId(pid: string): Promise<QuickSearchResult[]> {
+  const url = `https://ocpa-mainsite-afd-standard.azurefd.net/api/QuickSearch/GetSearchInfoByParcel?pid=${pid}`;
+
+  for (let attempt = 1; attempt <= EMPTY_RETRY_ATTEMPTS; attempt++) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(
+        `API request to ${url} failed with status ${response.status}`
+      );
+    }
+
+    const data = await response.json();
+    if (Array.isArray(data) && data.length > 0) {
+      return data as QuickSearchResult[];
+    }
+
+    logger.warn(
+      `Quick search for parcel ${pid} returned empty (attempt ${attempt}/${EMPTY_RETRY_ATTEMPTS})`
+    );
+    if (attempt < EMPTY_RETRY_ATTEMPTS) {
+      await delay(attempt * EMPTY_RETRY_BASE_DELAY_MS);
+    }
+  }
+
+  throw new Error(
+    `Quick search for parcel ${pid} returned empty after ${EMPTY_RETRY_ATTEMPTS} attempts`
+  );
+}
+
 async function fetchAllYearsNonAdValorem(parcelId: string): Promise<unknown[]> {
   const results: unknown[] = [];
   let taxYear = 0;
@@ -76,20 +129,18 @@ export async function fetchOrangeCountyData(
 ): Promise<Prepared> {
   logger.info('Orange County detected - using hardcoded API flow');
 
-  const cleanRequestId = requestId.replace(/-/g, '');
-
-  // First, fetch the quick search to get the parcelId
-  const quickSearchUrl = `https://ocpa-mainsite-afd-standard.azurefd.net/api/QuickSearch/GetSearchInfoByParcel?pid=${cleanRequestId}`;
-  const quickSearchResponse = await fetch(quickSearchUrl);
-  if (!quickSearchResponse.ok) {
+  // Strip every non-digit (seed ids may carry dashes/whitespace), then
+  // left-pad to 15 so 14-digit ids resolve. Never truncate longer ids.
+  const digits = requestId.replace(/\D/g, '');
+  if (digits.length > OCPA_PID_LENGTH) {
     throw new Error(
-      `API request to ${quickSearchUrl} failed with status ${quickSearchResponse.status}`
+      `Orange County parcel id "${requestId}" cleaned to ${digits.length} digits (> ${OCPA_PID_LENGTH}); cannot resolve`
     );
   }
-  const quickSearchData = await quickSearchResponse.json();
-  if (!Array.isArray(quickSearchData) || quickSearchData.length === 0) {
-    throw new Error('Quick search response is not a valid array or is empty');
-  }
+  const cleanRequestId = digits.padStart(OCPA_PID_LENGTH, '0');
+
+  // First, resolve the canonical parcelId (retries on transient empty result).
+  const quickSearchData = await resolveParcelId(cleanRequestId);
   const parcelId = quickSearchData[0]?.parcelId;
   if (!parcelId) {
     throw new Error('Failed to retrieve parcelId from quick search response');

--- a/tests/unit/lib/county-specific-prepare/orange.test.ts
+++ b/tests/unit/lib/county-specific-prepare/orange.test.ts
@@ -146,5 +146,19 @@ describe('fetchOrangeCountyData', () => {
       );
       expect(calls).toBe(1);
     });
+
+    it('fast-fails (no retry) on a structurally-unexpected non-array body', async () => {
+      let calls = 0;
+      const mockFetch = makeFetch(() => {
+        calls += 1;
+        return { ok: true, status: 200, body: { error: 'rate limited' } };
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(fetchOrangeCountyData('012027000000001')).rejects.toThrow(
+        /returned unexpected format/
+      );
+      expect(calls).toBe(1);
+    });
   });
 });

--- a/tests/unit/lib/county-specific-prepare/orange.test.ts
+++ b/tests/unit/lib/county-specific-prepare/orange.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { fetchOrangeCountyData } from '../../../../src/lib/county-specific-prepare/orange.js';
+
+// Minimal fetch stub matching the shape orange.ts consumes: { ok, status, json }.
+// Every PRC/QuickSearch endpoint is answered so the fetcher runs end-to-end;
+// only the QuickSearch behavior is varied per test.
+type QuickSearchHandler = (pid: string) => {
+  ok: boolean;
+  status: number;
+  body: unknown;
+};
+
+function makeFetch(quickSearch: QuickSearchHandler) {
+  return vi.fn(async (url: string) => {
+    if (url.includes('GetSearchInfoByParcel')) {
+      const pid = new URL(url).searchParams.get('pid') ?? '';
+      const { ok, status, body } = quickSearch(pid);
+      return { ok, status, json: async () => body } as unknown as Response;
+    }
+    // GetPRCTotalTaxes paginates until taxYear === 0.
+    if (url.includes('GetPRCTotalTaxes')) {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ taxYear: 0 }),
+      } as unknown as Response;
+    }
+    // GetPRCNonAdValorem and all other endpoints stop/accept on an empty array.
+    return {
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as unknown as Response;
+  });
+}
+
+describe('fetchOrangeCountyData', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  describe('parcel id zero-padding', () => {
+    it('left-pads a 14-digit seed id to 15 digits before QuickSearch', async () => {
+      const mockFetch = makeFetch(() => ({
+        ok: true,
+        status: 200,
+        body: [{ parcelId: 'CANON-1' }],
+      }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await fetchOrangeCountyData('12027000000001'); // 14 digits
+
+      const quickSearchCall = mockFetch.mock.calls.find(([u]) =>
+        String(u).includes('GetSearchInfoByParcel')
+      );
+      expect(quickSearchCall).toBeDefined();
+      expect(String(quickSearchCall![0])).toContain('pid=012027000000001');
+    });
+
+    it('leaves an already-15-digit id unchanged', async () => {
+      const mockFetch = makeFetch(() => ({
+        ok: true,
+        status: 200,
+        body: [{ parcelId: 'CANON-1' }],
+      }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await fetchOrangeCountyData('012027000000001'); // 15 digits
+
+      const quickSearchCall = mockFetch.mock.calls.find(([u]) =>
+        String(u).includes('GetSearchInfoByParcel')
+      );
+      expect(String(quickSearchCall![0])).toContain('pid=012027000000001');
+    });
+
+    it('strips dashes/non-digits then pads', async () => {
+      const mockFetch = makeFetch(() => ({
+        ok: true,
+        status: 200,
+        body: [{ parcelId: 'CANON-1' }],
+      }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await fetchOrangeCountyData('12-027-000000001'); // dashes + 14 digits
+
+      const quickSearchCall = mockFetch.mock.calls.find(([u]) =>
+        String(u).includes('GetSearchInfoByParcel')
+      );
+      expect(String(quickSearchCall![0])).toContain('pid=012027000000001');
+    });
+
+    it('throws when the cleaned id exceeds 15 digits (never truncates)', async () => {
+      const mockFetch = makeFetch(() => ({
+        ok: true,
+        status: 200,
+        body: [{ parcelId: 'CANON-1' }],
+      }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(
+        fetchOrangeCountyData('1234567890123456') // 16 digits
+      ).rejects.toThrow(/> 15/);
+    });
+  });
+
+  describe('retry-on-empty for QuickSearch', () => {
+    it('retries when QuickSearch returns an empty array and succeeds on a later attempt', async () => {
+      let calls = 0;
+      const mockFetch = makeFetch(() => {
+        calls += 1;
+        if (calls < 3) {
+          return { ok: true, status: 200, body: [] }; // transient empty
+        }
+        return { ok: true, status: 200, body: [{ parcelId: 'CANON-1' }] };
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      const result = await fetchOrangeCountyData('012027000000001');
+
+      expect(calls).toBe(3);
+      expect(result.type).toBe('json');
+    });
+
+    it('throws not-found only after retries are exhausted', async () => {
+      const mockFetch = makeFetch(() => ({ ok: true, status: 200, body: [] }));
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(fetchOrangeCountyData('012027000000001')).rejects.toThrow(
+        /returned empty after 4 attempts/
+      );
+    });
+
+    it('does not retry genuine HTTP errors', async () => {
+      let calls = 0;
+      const mockFetch = makeFetch(() => {
+        calls += 1;
+        return { ok: false, status: 500, body: null };
+      });
+      global.fetch = mockFetch as unknown as typeof fetch;
+
+      await expect(fetchOrangeCountyData('012027000000001')).rejects.toThrow(
+        /failed with status 500/
+      );
+      expect(calls).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Two defects in the Orange native fetcher (`src/lib/county-specific-prepare/orange.ts`), both found in the Orange pilot: (1) **no zero-padding** — OCPA QuickSearch needs a 15-digit pid but the seed has mixed 14/15-digit ids (stripped leading zeros); a 14-digit id returns `[]` and the parcel is lost → now `padStart(15,'0')` (guard >15). (2) **no retry-on-empty** — OCPA intermittently returns `[]` for a valid id (~16% first-pass, all recovered on retry) → QuickSearch now retries on empty with backoff; real HTTP errors are not retried. Orange-scoped (no shared helper touched). 7 new unit tests; tsc + suite green.